### PR TITLE
Remove numeric length parameter in postgres schema generation.

### DIFF
--- a/src/data/brk.prepare.json
+++ b/src/data/brk.prepare.json
@@ -349,7 +349,7 @@
           },
           {
             "name": "kadgrootte",
-            "type": "NUMERIC(22)"
+            "type": "NUMERIC"
           },
           {
             "name": "koopsom",

--- a/src/gobprepare/cloner/mapping/oracle_to_postgres.py
+++ b/src/gobprepare/cloner/mapping/oracle_to_postgres.py
@@ -28,7 +28,7 @@ def _oracle_number_to_postgres(length: int = None, precision: int = None, scale:
     elif length <= 18:
         return 'BIGINT'
     else:
-        return f'NUMERIC({length})'
+        return f'NUMERIC'
 
 
 _oracle_postgresql_column_mapping = {

--- a/src/tests/gobprepare/cloner/mapping/test_oracle_to_postgres.py
+++ b/src/tests/gobprepare/cloner/mapping/test_oracle_to_postgres.py
@@ -17,8 +17,8 @@ class TestOracleToPostgresMapping(TestCase):
             ((9, None, None), 'INT'),
             ((10, None, None), 'BIGINT'),
             ((18, None, None), 'BIGINT'),
-            ((19, None, None), 'NUMERIC(19)'),
-            ((428, None, None), 'NUMERIC(428)'),
+            ((19, None, None), 'NUMERIC'),
+            ((428, None, None), 'NUMERIC'),
         ]
 
         for params, result in cases:


### PR DESCRIPTION
... Because a single parameter to the Numeric column in Postgres is precision, and not length.