### PR TITLE
Add table and columns for partial brk imports

### DIFF
--- a/src/data/brk.prepare.json
+++ b/src/data/brk.prepare.json
@@ -1421,7 +1421,6 @@
       ],
       "query_src": "file",
       "query": "data/sql/brk/brk.store_last_id.sql"
-    },
-    
+    }
   ]
 }

--- a/src/data/brk.prepare.json
+++ b/src/data/brk.prepare.json
@@ -554,7 +554,15 @@
           {
             "name": "expiration_date",
             "type": "TIMESTAMP"
-          }
+          },
+          {
+            "name": "creation",
+            "type": "TIMESTAMP"
+          },
+          {
+            "name": "modification",
+            "type": "TIMESTAMP"
+          },
         ]
       }
     },
@@ -672,7 +680,15 @@
           {
             "name": "einddatum",
             "type": "TIMESTAMP WITHOUT TIME ZONE"
-          }
+          },
+          {
+            "name": "creation",
+            "type": "TIMESTAMP"
+          },
+          {
+            "name": "modification",
+            "type": "TIMESTAMP"
+          },
         ]
       }
     },
@@ -1392,6 +1408,20 @@
       ],
       "query_src": "file",
       "query": "data/sql/brk/kot.update_a_geometrie.sql"
-    }
+    },
+    {
+      "type": "execute_sql",
+      "description": "Store last imported id's for collections without modification date",
+      "id": "store_last_id",
+      "depends_on": [
+        "create_indexes_akt",
+        "create_indexes_art",
+        "select_sdl",
+        "select_sjt"
+      ],
+      "query_src": "file",
+      "query": "data/sql/brk/brk.store_last_id.sql"
+    },
+    
   ]
 }

--- a/src/data/brk.prepare.json
+++ b/src/data/brk.prepare.json
@@ -562,7 +562,7 @@
           {
             "name": "modification",
             "type": "TIMESTAMP"
-          },
+          }
         ]
       }
     },
@@ -688,7 +688,7 @@
           {
             "name": "modification",
             "type": "TIMESTAMP"
-          },
+          }
         ]
       }
     },

--- a/src/data/sql/brk/brk.store_last_id.sql
+++ b/src/data/sql/brk/brk.store_last_id.sql
@@ -1,0 +1,62 @@
+CREATE SCHEMA IF NOT EXISTS brk_metadata;
+
+CREATE TABLE IF NOT EXISTS brk_metadata.last_source_id (
+  id SERIAL,
+  collection VARCHAR(50) NOT NULL,
+  id_column VARCHAR(63) NOT NULL,
+  last_id INTEGER NOT NULL,
+  date_registered TIMESTAMP NOT NULL,
+  PRIMARY KEY (id)
+)
+
+INSERT INTO brk_metadata.last_source_id (
+  collection,
+  id_column,
+  last_id,
+  date_registered
+)
+SELECT
+  'aantekening_kadastraal_object' AS collection,
+  'nrn_atg_id' AS id_column,
+  max(nrn_atg_id) AS last_id,
+  now() AS date_registered
+FROM brk_prepared.aantekening_kadastraal_object;
+
+INSERT INTO brk_metadata.last_source_id (
+  collection,
+  id_column,
+  last_id,
+  date_registered
+)
+SELECT
+  'aantekening_recht' AS collection,
+  'nrn_atg_id' AS id_column,
+  max(nrn_atg_id) AS last_id,
+  now() AS date_registered
+FROM brk_prepared.aantekening_kadastraal_object;
+
+INSERT INTO brk_metadata.last_source_id (
+  collection,
+  id_column,
+  last_id,
+  date_registered
+)
+SELECT
+  'stukdeel' AS collection,
+  'nrn_sdl_id' AS id_column,
+  max(nrn_sdl_id) AS last_id,
+  now() AS date_registered
+FROM brk_prepared.stukdeel;
+
+INSERT INTO brk_metadata.last_source_id (
+  collection,
+  id_column,
+  last_id,
+  date_registered
+)
+SELECT
+  'kadastraal_subject' AS collection,
+  'nrn_sjt_id' AS id_column,
+  max(nrn_sjt_id) AS last_id,
+  now() AS date_registered
+FROM brk_prepared.kadastraal_subject;

--- a/src/data/sql/brk/select.tenaamstelling.sql
+++ b/src/data/sql/brk/select.tenaamstelling.sql
@@ -23,6 +23,8 @@ SELECT t.identificatie              	AS brk_tng_id
 ,      zrt.rust_op_kadastraalobj_volgnr AS volgnummer
 ,      zrt.zrt_begindatum               AS begindatum
 ,      least(zrt.expiration_date, atg.einddatum) AS einddatum
+,      zrt.creation                         AS creation
+,      zrt.modification                     AS modification
 FROM BRK.TENAAMSTELLING t
 LEFT JOIN BRK.TENAAMSTELLING_ISGEBASEERDOP g    ON t.id=g.tenaamstelling_id
 LEFT JOIN BRK.C_SAMENWERKINGSVERBAND s          ON t.verkregen_namens_code=s.code

--- a/src/data/sql/brk/select.zakelijk_recht.sql
+++ b/src/data/sql/brk/select.zakelijk_recht.sql
@@ -78,6 +78,8 @@ SELECT zrt.id
       ,kot.status_code AS kot_status_code
       ,kot.toestandsdatum       AS toestandsdatum
       ,kot.expiration_date AS expiration_date
+      ,kot.creation AS creation
+      ,kot.modification AS modification
 FROM   brk.zakelijkrecht zrt
 LEFT JOIN (
     SELECT


### PR DESCRIPTION
A new table and schema was added to store the last ids for collection without creation/modification dates for partial imports. ZRT and TNG use the creation/modification dates of KOT.