### PR TITLE
Add wkpb to prepare to import the relation table

### DIFF
--- a/src/data/sql/brk/brk_prep.kot.indexes.sql
+++ b/src/data/sql/brk/brk_prep.kot.indexes.sql
@@ -1,2 +1,3 @@
 CREATE INDEX ON brk_prep.kadastraal_object(index_letter);
 CREATE INDEX ON brk_prep.kadastraal_object(nrn_kot_id, nrn_kot_volgnr);
+CREATE INDEX ON brk_prep.kadastraal_object(kadastrale_aanduiding);

--- a/src/data/sql/wkpb/select.beperkingen.sql
+++ b/src/data/sql/wkpb/select.beperkingen.sql
@@ -1,0 +1,28 @@
+SELECT
+  b1.registernummer || p1.belast_kadastraal_object AS id,
+  b1.registernummer AS src_id,
+  b1.volgnummer AS src_volgnummer,
+  p1.belast_kadastraal_object AS bronwaarde
+FROM (
+  SELECT
+  b.id
+  , b.registernummer
+  , b.volgnummer
+  FROM prb.beperking b
+  -- select max volgnummer van iedere beperking
+  LEFT JOIN (
+    SELECT id, MAX(volgnummer) AS volgnummer FROM prb.beperking GROUP BY id
+  ) m ON m.id = b.id AND m.volgnummer = b.volgnummer
+  WHERE b.registernummer IS NOT NULL
+  AND m.id IS NOT NULL
+) b1
+LEFT OUTER JOIN (
+  SELECT
+    p.id_beperking,
+    p.begin_volgnummer,
+    p.einde_volgnummer,
+    p.gemcod || p.sectie || LPAD(p.pnum, 5, '0') || p.objindl || LPAD(p.objindn, 4, '0') AS belast_kadastraal_object
+  FROM prb.beperking_perceel p
+) p1 ON b1.id = p1.id_beperking
+AND b1.volgnummer BETWEEN p1.begin_volgnummer AND CASE p1.einde_volgnummer WHEN 0 THEN 999999 ELSE p1.einde_volgnummer END
+WHERE p1.belast_kadastraal_object IS NOT NULL

--- a/src/data/sql/wkpb/select.rel_wkpb_bpg_brk_kot_belast_kadastrale_objecten.sql
+++ b/src/data/sql/wkpb/select.rel_wkpb_bpg_brk_kot_belast_kadastrale_objecten.sql
@@ -1,0 +1,13 @@
+SELECT
+  bpg.id,
+  bpg.src_id,
+  bpg.src_volgnummer,
+  bpg.bronwaarde,
+  kot.brk_kot_id                AS dst_id,
+  kot.nrn_kot_volgnr            AS dst_volgnummer
+FROM
+  wkpb_prep.beperkingen bpg
+INNER JOIN
+  brk_prepared.kadastraal_object kot
+ON
+  bpg.bronwaarde = kot.kadastrale_aanduiding

--- a/src/data/wkpb.prepare.json
+++ b/src/data/wkpb.prepare.json
@@ -1,0 +1,97 @@
+{
+  "version": "0.1",
+  "name": "WKPB",
+  "catalogue": "wkpb",
+  "source": {
+    "application": "Neuron",
+    "type": "oracle"
+  },
+  "destination": {
+    "application": "GOBPrepare",
+    "type": "postgres"
+  },
+  "publish_schemas": {
+    "wkpb_prep": "wkpb_prepared"
+  },
+  "actions": [
+    {
+      "type": "clear",
+      "schemas": [
+        "wkpb_prep"
+      ],
+      "id": "clear_schemas"
+    },
+    {
+      "type": "select",
+      "source": "src",
+      "query": "data/sql/wkpb/select.beperkingen.sql",
+      "query_src": "file",
+      "destination_table": {
+        "name": "wkpb_prep.beperkingen",
+        "create": true,
+        "columns": [
+          {
+            "name": "id",
+            "type": "VARCHAR(240)"
+          },
+          {
+            "name": "src_id",
+            "type": "VARCHAR(240)"
+          },
+          {
+            "name": "src_volgnummer",
+            "type": "INT"
+          },
+          {
+            "name": "bronwaarde",
+            "type": "VARCHAR(240)"
+          }
+        ]
+      },
+      "depends_on": [
+        "clear_schemas"
+      ],
+      "id": "select_beperkingen"
+    },
+    {
+      "type": "select",
+      "source": "dst",
+      "query": "data/sql/wkpb/select.rel_wkpb_bpg_brk_kot_belast_kadastrale_objecten.sql",
+      "query_src": "file",
+      "destination_table": {
+        "name": "wkpb_prep.rel_wkpb_bpg_brk_kot_belast_kadastrale_objecten",
+        "create": true,
+        "columns": [
+          {
+            "name": "id",
+            "type": "VARCHAR(240)"
+          },
+          {
+            "name": "src_id",
+            "type": "VARCHAR(240)"
+          },
+          {
+            "name": "src_volgnummer",
+            "type": "INT"
+          },
+          {
+            "name": "dst_id",
+            "type": "VARCHAR(240)"
+          },
+          {
+            "name": "dst_volgnummer",
+            "type": "INT"
+          },
+          {
+            "name": "bronwaarde",
+            "type": "VARCHAR(240)"
+          }
+        ]
+      },
+      "depends_on": [
+        "select_beperkingen"
+      ],
+      "id": "select_rel_wkpb_bpg_brk_kot_belast_kadastrale_objecten"
+    }
+  ]
+}


### PR DESCRIPTION
Uses the current import query for rel_wkpb_bpg_brk_kot_belast_kadastrale objecten and joins the kadastrale objecten into a relation table. This can be imported in GOB-Import. Also add an index to kadastrale_aanduiding on the KOT object to speed up the join.