### PR TITLE
Change prepare BRK baghulptabel query to avoid double addresses

### DIFF
--- a/src/data/sql/brk/materialized_view.baghulptabel.sql
+++ b/src/data/sql/brk/materialized_view.baghulptabel.sql
@@ -19,8 +19,7 @@ create materialized view brk.baghulptabel as select
 	        woonplaatsnaam)
 	    ) as adressen
 from (
-SELECT kas.id
-      ,kas.kadastraalobject_id
+SELECT kas.kadastraalobject_id
       ,kas.kadastraalobject_volgnummer
       ,aot.bag_id
       ,kas.openbareruimtenaam
@@ -34,8 +33,7 @@ LEFT JOIN   brk.adresseerbaar_object aot
 ON     kas.adresseerbaar_object_id = aot.id
 WHERE  kas.adresseerbaar_object_id IS null
 UNION
-SELECT kas.id
-      ,kas.kadastraalobject_id
+SELECT kas.kadastraalobject_id
       ,kas.kadastraalobject_volgnummer
       ,aot.bag_id
       ,aot.openbareruimtenaam


### PR DESCRIPTION
"Something" has changed that caused double addresses to become errors. Still figuring out why double addresses didn't cause trouble before (working fine in PROD with the same addresses, and the previous ACC database contained the same addresses), but removing double addresses in prepare will solve the issue anyway (and is much cleaner).