### PR TITLE
Docker Fix

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM amsterdam/python:latest
+FROM amsterdam/python:3.7.2-stretch
 MAINTAINER datapunt@amsterdam.nl
 
 # Install gobprepare in /app folder

--- a/src/Dockerfile.test
+++ b/src/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM amsterdam/python:latest
+FROM amsterdam/python:3.7.2-stretch
 MAINTAINER datapunt@amsterdam.nl
 
 # Install gobprepare in /app folder


### PR DESCRIPTION
Change Python docker image to python:3.7.2-stretch
This image is equal to the current python:latest image.