### PR TITLE
Ignore a specific stukdeel

### DIFF
--- a/src/data/sql/brk/select.stukdeel.sql
+++ b/src/data/sql/brk/select.stukdeel.sql
@@ -149,6 +149,8 @@ WITH stukdelen AS (SELECT sdl.identificatie                         AS brk_sdl_i
                        GROUP BY stukdeel_identificatie
                    ) asg ON (asg.stukdeel_identificatie = sdl.identificatie)
                             JOIN brk.bestand bsd ON (1 = 1)
+    -- Exclude NL.KAD.Stukdeel.33029100 since it has 287.000 relations
+    WHERE sdl.identificatie <> 'NL.KAD.Stukdeel.33029100'
 )
 -- Interleave rows for import to avoid a heavily unbalanced tabel.
 SELECT


### PR DESCRIPTION
The stukdeel has too many relations to aantekening kadastraal object, which causes errors when export the data. The issue will be checked, but untill then we will ignore this stukdeel