### PR TITLE
Introduce 'create_table' action

### DIFF
--- a/src/data/brk2.prepare.json
+++ b/src/data/brk2.prepare.json
@@ -119,8 +119,9 @@
       ]
     },
     {
-      "type": "execute_sql",
+      "type": "create_table",
       "description": "Select meta",
+      "table_name": "brk2_prep.meta",
       "query_src": "file",
       "query": "data/sql/brk2/select.meta.sql",
       "id": "select_meta",
@@ -129,8 +130,9 @@
       ]
     },
     {
-      "type":"execute_sql",
+      "type": "create_table",
       "description": "Select KOT",
+      "table_name": "brk2_prep.kadastraal_object",
       "query_src": "file",
       "query": "data/sql/brk2/select.kadastraal_object.sql",
       "id": "select_kot",
@@ -141,8 +143,9 @@
       ]
     },
     {
-      "type": "execute_sql",
+      "type": "create_table",
       "description": "Select ZRT",
+      "table_name": "brk2_prep.zakelijk_recht",
       "query_src": "file",
       "query": "data/sql/brk2/select.zakelijk_recht.sql",
       "id": "select_zrt",
@@ -226,8 +229,9 @@
       "query": "data/sql/brk2/kot.remove_duplicate_ontstaan_uit_relations.sql"
     },
     {
-      "type": "execute_sql",
+      "type": "create_table",
       "description": "Select TNG",
+      "table_name": "brk2_prep.tenaamstelling",
       "query_src": "file",
       "query": "data/sql/brk2/select.tenaamstelling.sql",
       "id": "select_tng",
@@ -236,8 +240,9 @@
       ]
     },
     {
-      "type": "execute_sql",
+      "type": "create_table",
       "description": "Select AKT",
+      "table_name": "brk2_prep.aantekening_kadastraal_object",
       "query_src": "file",
       "query": "data/sql/brk2/select.aantekening_kadastraal_object.sql",
       "id": "select_akt",
@@ -247,8 +252,9 @@
       ]
     },
     {
-      "type": "execute_sql",
+      "type": "create_table",
       "description": "Select ART",
+      "table_name": "brk2_prep.aantekening_recht",
       "query_src": "file",
       "query": "data/sql/brk2/select.aantekening_recht.sql",
       "id": "select_art",
@@ -269,8 +275,9 @@
       "query_src": "file"
     },
     {
-      "type": "execute_sql",
+      "type": "create_table",
       "description": "Select SJT",
+      "table_name": "brk2_prep.kadastraal_subject",
       "query_src": "file",
       "query": "data/sql/brk2/select.kadastraal_subject.sql",
       "id": "select_sjt",
@@ -281,8 +288,9 @@
       ]
     },
     {
-      "type": "execute_sql",
+      "type": "create_table",
       "description": "Select KSE",
+      "table_name": "brk2_prep.kadastrale_sectie",
       "query_src": "file",
       "query": "data/sql/brk2/select.kadastrale_sectie.sql",
       "id": "select_kse",
@@ -291,8 +299,9 @@
       ]
     },
     {
-      "type": "execute_sql",
+      "type": "create_table",
       "description": "Select KGE",
+      "table_name": "brk2_prep.kadastrale_gemeente",
       "query_src": "file",
       "query": "data/sql/brk2/select.kadastrale_gemeente.sql",
       "id": "select_kge",
@@ -301,8 +310,9 @@
       ]
     },
     {
-      "type": "execute_sql",
+      "type": "create_table",
       "description": "Select KCE",
+      "table_name": "brk2_prep.kadastrale_gemeentecode",
       "query_src": "file",
       "query": "data/sql/brk2/select.kadastrale_gemeentecode.sql",
       "id": "select_kce",
@@ -311,8 +321,9 @@
       ]
     },
     {
-      "type": "execute_sql",
+      "type": "create_table",
       "description": "Select SDL",
+      "table_name": "brk2_prep.stukdeel",
       "query_src": "file",
       "query": "data/sql/brk2/select.stukdeel.sql",
       "id": "select_sdl",

--- a/src/data/sql/brk2/select.aantekening_kadastraal_object.sql
+++ b/src/data/sql/brk2/select.aantekening_kadastraal_object.sql
@@ -1,4 +1,3 @@
-CREATE TABLE brk2_prep.aantekening_kadastraal_object AS
 SELECT atg.identificatie                                               AS identificatie,
        atg.id                                                          AS __neuron_id,
        koa.kadastraalobject_volgnummer                                 AS volgnummer,

--- a/src/data/sql/brk2/select.aantekening_recht.sql
+++ b/src/data/sql/brk2/select.aantekening_recht.sql
@@ -1,4 +1,3 @@
-CREATE TABLE brk2_prep.aantekening_recht AS
 SELECT atg.id                                            AS neuron_id,
        atg.identificatie                                 AS identificatie,
        atg.einddatum_recht                               AS einddatum_recht,

--- a/src/data/sql/brk2/select.kadastraal_object.sql
+++ b/src/data/sql/brk2/select.kadastraal_object.sql
@@ -1,4 +1,3 @@
-CREATE TABLE brk2_prep.kadastraal_object AS
 SELECT kot.identificatie                    AS identificatie,
        kot.volgnummer                       AS volgnummer,
        kot.id                               AS id,

--- a/src/data/sql/brk2/select.kadastraal_subject.sql
+++ b/src/data/sql/brk2/select.kadastraal_subject.sql
@@ -1,4 +1,3 @@
-CREATE TABLE brk2_prep.kadastraal_subject AS
 WITH subjecten AS ((SELECT id                            AS nrn_sjt_id
                          , identificatie                 AS Identificatie_subject
                          , 'NATUURLIJK PERSOON'          AS Type_subject

--- a/src/data/sql/brk2/select.kadastrale_gemeente.sql
+++ b/src/data/sql/brk2/select.kadastrale_gemeente.sql
@@ -2,7 +2,6 @@
 -- Collect the polygons and Use ST_UnaryUnion to remove conflicting linestrings
 -- Take the exterior ring
 -- The last union is to create MULTIPOLYGONs from areas with the same identificatie
-CREATE TABLE brk2_prep.kadastrale_gemeente AS
 SELECT gc3.identificatie       AS identificatie,
        ST_Union(gc3.geometrie) AS geometrie,
        gc3.ligt_in_gemeente    AS ligt_in_brk_gemeente

--- a/src/data/sql/brk2/select.kadastrale_gemeentecode.sql
+++ b/src/data/sql/brk2/select.kadastrale_gemeentecode.sql
@@ -2,7 +2,6 @@
 -- Collect the polygons and Use ST_UnaryUnion to remove conflicting linestrings
 -- Take the exterior ring
 -- The last union is to create MULTIPOLYGONs from areas with the same identificatie
-CREATE TABLE brk2_prep.kadastrale_gemeentecode AS
 SELECT gc3.identificatie,
        ST_Union(gc3.geometrie)                 AS geometrie,
        gc3.is_onderdeel_van_kadastralegemeente AS is_onderdeel_van_brk_kadastrale_gemeente

--- a/src/data/sql/brk2/select.kadastrale_sectie.sql
+++ b/src/data/sql/brk2/select.kadastrale_sectie.sql
@@ -1,4 +1,3 @@
-CREATE TABLE brk2_prep.kadastrale_sectie AS
 SELECT aangeduid_door_kadastralegemeentecode_omschrijving || aangeduid_door_kadastralesectie AS identificatie,
        aangeduid_door_kadastralesectie                                                       AS code,
        aangeduid_door_kadastralegemeentecode_omschrijving                                    AS is_onderdeel_van_brk_kadastrale_gemeentecode,

--- a/src/data/sql/brk2/select.meta.sql
+++ b/src/data/sql/brk2/select.meta.sql
@@ -1,4 +1,3 @@
-CREATE TABLE brk2_prep.meta AS
 SELECT
     1 as id,
     bsd.brk_bsd_toestandsdatum as toestandsdatum,

--- a/src/data/sql/brk2/select.stukdeel.sql
+++ b/src/data/sql/brk2/select.stukdeel.sql
@@ -1,4 +1,3 @@
-CREATE TABLE brk2_prep.stukdeel AS
 SELECT sdl.id                                                            AS id,
        sdl.identificatie                                                 AS identificatie,
        sdl.aardstukdeel_code                                             AS aard_code,

--- a/src/data/sql/brk2/select.tenaamstelling.sql
+++ b/src/data/sql/brk2/select.tenaamstelling.sql
@@ -3,7 +3,6 @@
 -- the source database.
 -- We get these attributes from the brk2_prep.zakelijk_recht table instead of from the kadastraalobject table from the
 -- brk schema, because the kadastraal object references aren't populated on all ZRT objects in the brk schema.
-CREATE TABLE brk2_prep.tenaamstelling AS
 SELECT tng.identificatie                                               AS identificatie,
        tng.id                                                          AS neuron_id,
        zrt.volgnummer                                                  AS volgnummer,

--- a/src/data/sql/brk2/select.zakelijk_recht.sql
+++ b/src/data/sql/brk2/select.zakelijk_recht.sql
@@ -1,4 +1,3 @@
-CREATE TABLE brk2_prep.zakelijk_recht AS
 WITH asg_codes(code, omschrijving) AS (VALUES (1, 'HoofdSplitsing'),
                                               (2, 'OnderSplitsing'),
                                               (3, 'SplitsingAfkoopErfpacht')),

--- a/src/gobprepare/prepare_client.py
+++ b/src/gobprepare/prepare_client.py
@@ -174,6 +174,12 @@ class PrepareClient:
         logger.info(f"Imported {rows_imported} rows from CSV to table {action['destination']}")
         return rows_imported
 
+    def action_create_table(self, action: dict):
+        query = self._get_query(action)
+        create_query = f"CREATE TABLE {action['table_name']} AS {query}"
+        self._dst_datastore.execute(create_query)
+        logger.info(f"Created table '{action['table_name']}'")
+
     def action_import_api(self, action: dict):
         """Import API action. Import API into destination database action.
 
@@ -225,6 +231,9 @@ class PrepareClient:
             result["rows_copied"] = self.action_select(action)
         elif action["type"] == "execute_sql":
             self.action_execute_sql(action)
+            result["executed"] = "OK"
+        elif action["type"] == "create_table":
+            self.action_create_table(action)
             result["executed"] = "OK"
         elif action["type"] == "import_csv":
             result["rows_imported"] = self.action_import_csv(action)

--- a/src/tests/gobprepare/test_prepare_client.py
+++ b/src/tests/gobprepare/test_prepare_client.py
@@ -234,6 +234,20 @@ class TestPrepareClient(TestCase):
         mock_importer.assert_called_with(prepare_client._dst_datastore, action)
         mock_importer_instance.import_csv.assert_called_once()
 
+    def test_action_create_table(self, mock_logger):
+        action = {
+            "id": "create_this_table",
+            "type": "create_table",
+            "table_name": "schema.table_name",
+            "query": ["select * from laladiela"],
+            "query_src": "string"
+        }
+        prepare_client = PrepareClient(self.mock_dataset, self.mock_msg)
+        prepare_client._dst_datastore = MagicMock()
+        prepare_client._run_prepare_action(action)
+        prepare_client._dst_datastore.execute.assert_called_with("CREATE TABLE schema.table_name AS select * from laladiela")
+        mock_logger.info.assert_called_with("Created table 'schema.table_name'")
+
     @patch("gobprepare.prepare_client.SqlAPIImporter", autospec=True)
     def test_action_import_api(self, mock_importer, mock_logger):
         action = {


### PR DESCRIPTION
No new functionality, just a way to remove the "CREATE TABLE" lines from the SQL files, so that we have more control later on how the tables are created - in preparation for cstore/citus.