### PR TITLE
Tasks: rename 'id' field to 'task_name' and place in header

### DIFF
--- a/src/gobprepare/prepare_client.py
+++ b/src/gobprepare/prepare_client.py
@@ -281,7 +281,7 @@ class PrepareClient:
         tasks = []
         for table_name in table_names:
             tasks.append({
-                'id': action['id'] + '__' + table_name.lower(),
+                'task_name': action['id'] + '__' + table_name.lower(),
                 'dependencies': action.get('depends_on', []),
                 'extra_msg': {
                     'override': {
@@ -293,12 +293,12 @@ class PrepareClient:
                 }
             })
 
-        ids = [task['id'] for task in tasks]
+        dependencies = [task['task_name'] for task in tasks]
 
         # Create join action with dependencies on new steps
         tasks.append({
-            'id': action['id'],
-            'dependencies': ids,
+            'task_name': action['id'],
+            'dependencies': dependencies,
             'extra_msg': {
                 'override': {
                     'type': 'join_actions'
@@ -320,7 +320,7 @@ class PrepareClient:
                 tasks.extend(self._split_clone_action(action))
             else:
                 tasks.append({
-                    'id': action['id'],
+                    'task_name': action['id'],
                     'dependencies': action.get('depends_on', []),
                 })
         return tasks
@@ -365,14 +365,14 @@ class PrepareClient:
 
         :return:
         """
-        taskid = self.msg['id']
-        action = [action for action in self._actions if action['id'] == taskid]
+        task_name = self.header['task_name']
+        action = [action for action in self._actions if action['id'] == task_name]
 
         if not action and 'original_action' in self.msg:
             action = [action for action in self._actions if action['id'] == self.msg['original_action']]
 
         if not action:
-            raise GOBException(f"Unknown action with id {taskid}")
+            raise GOBException(f"Unknown action with id {task_name}")
 
         action = action[0]
 
@@ -384,7 +384,7 @@ class PrepareClient:
         try:
             self._run_prepare_action(action)
         except DuplicateTableError as err:
-            print(f'WARNING: {err}, ignoring duplicate for task \'{taskid}\'')
+            print(f"WARNING: {err}, ignoring duplicate for task '{task_name}'")
             return False
         else:
             return self._get_result()

--- a/src/tests/gobprepare/test_prepare_client.py
+++ b/src/tests/gobprepare/test_prepare_client.py
@@ -479,10 +479,10 @@ class TestPrepareClient(TestCase):
         }]
 
         self.assertEqual([{
-            'id': 'action1',
+            'task_name': 'action1',
             'dependencies': ['dep1', 'dep2']
         }, {
-            'id': 'action2',
+            'task_name': 'action2',
             'dependencies': []
         }], prepare_client._create_tasks())
 
@@ -497,7 +497,7 @@ class TestPrepareClient(TestCase):
         self.assertEqual(prepare_client._split_clone_action.return_value, result)
 
     def test_get_task_message(self, mock_logger):
-        tasks = [{'id': 'task1', 'dependencies': []}, {'id': 'task2', 'dependencies': ['task1']}]
+        tasks = [{'task_name': 'task1', 'dependencies': []}, {'task_name': 'task2', 'dependencies': ['task1']}]
         prepare_client = PrepareClient(self.mock_dataset, self.mock_msg)
         prepare_client.header = {'hea': 'der', 'catalogue': 'somecatalogue'}
         prepare_client.msg = {'prepare_config': 'config.json'}
@@ -525,7 +525,7 @@ class TestPrepareClient(TestCase):
         prepare_client._get_result = MagicMock()
 
         prepare_client._actions = [{'id': 'some_id'}, {'id': 'other_id'}]
-        prepare_client.msg = {'id': 'other_id'}
+        prepare_client.header = {'task_name': 'other_id'}
 
         result = prepare_client.run_prepare_task()
         prepare_client._run_prepare_action.assert_called_with(prepare_client._actions[1])
@@ -535,7 +535,7 @@ class TestPrepareClient(TestCase):
     def test_run_prepare_task_no_action(self, mock_logger):
         prepare_client = PrepareClient(self.mock_dataset, self.mock_msg)
         prepare_client._actions = [{'id': 'some_id'}, {'id': 'other_id'}]
-        prepare_client.msg = {'id': 'nonexistent'}
+        prepare_client.header = {'task_name': 'nonexistent'}
 
         with self.assertRaises(GOBException):
             prepare_client.run_prepare_task()
@@ -543,7 +543,7 @@ class TestPrepareClient(TestCase):
     def test_run_prepare_task_duplicate_table(self, mock_logger):
         prepare_client = PrepareClient(self.mock_dataset, self.mock_msg)
         prepare_client._actions = [{'id': 'some_id'}, {'id': 'other_id'}]
-        prepare_client.msg = {'id': 'some_id'}
+        prepare_client.header = {'task_name': 'some_id'}
         prepare_client._run_prepare_action = MagicMock()
         prepare_client._run_prepare_action.side_effect = DuplicateTableError
         result = prepare_client.run_prepare_task()
@@ -556,7 +556,8 @@ class TestPrepareClient(TestCase):
         prepare_client.disconnect = MagicMock()
         prepare_client._get_result = MagicMock()
         prepare_client._actions = [{'id': 'some_id'}, {'id': 'other_id', 'type': 'sometype'}]
-        prepare_client.msg = {'id': 'some_other_id', 'original_action': 'other_id', 'override': {'type': 'newtype'}}
+        prepare_client.header = {'task_name': 'some_other_id'}
+        prepare_client.msg = {'original_action': 'other_id', 'override': {'type': 'newtype'}}
 
         prepare_client.run_prepare_task()
 
@@ -619,7 +620,7 @@ class TestPrepareClient(TestCase):
         result = prepare_client._split_clone_action(action)
 
         expected_result = [{
-            'id': 'some_clone_action__table_a',
+            'task_name': 'some_clone_action__table_a',
             'dependencies': action['depends_on'],
             'extra_msg': {
                 'override': {
@@ -629,7 +630,7 @@ class TestPrepareClient(TestCase):
                 'original_action': 'some_clone_action',
             }
         }, {
-            'id': 'some_clone_action__table_b',
+            'task_name': 'some_clone_action__table_b',
             'dependencies': action['depends_on'],
             'extra_msg': {
                 'override': {
@@ -639,7 +640,7 @@ class TestPrepareClient(TestCase):
                 'original_action': 'some_clone_action',
             }
         }, {
-            'id': action['id'],
+            'task_name': action['id'],
             'dependencies': ['some_clone_action__table_a', 'some_clone_action__table_b'],
             'extra_msg': {
                 'override': {


### PR DESCRIPTION
- task_name in header so that this can be used when running standalone
- id to task_name is for readability - now we're at it

Should be deployed together with https://github.com/Amsterdam/GOB-Workflow/pull/308