### PR TITLE
Extract default 'publish_schema' action into explicit task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ htmlcov
 
 .env
 .idea
+message-result

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - ./src/tests:/app/tests
       - ${GOB_CORE_DIR-../GOB-Core}:/app/GOB-Core
       - ${GOB_CONFIG_DIR-../GOB-Config}:/app/GOB-Config
+      - ./message-result:/airflow/xcom
 
   prepare_database:
     image: amsterdam/postgres11

--- a/src/data/brk.prepare.json
+++ b/src/data/brk.prepare.json
@@ -8,9 +8,6 @@
   "destination": {
     "application": "GOBPrepare"
   },
-  "publish_schemas": {
-    "brk_prep": "brk_prepared"
-  },
   "actions": [
     {
       "type": "clear",
@@ -1424,6 +1421,14 @@
       ],
       "query_src": "file",
       "query": "data/sql/brk/brk.store_last_id.sql"
+    },
+    {
+      "type": "publish_schemas",
+      "id": "publish_schemas",
+      "publish_schemas": {
+        "brk_prep": "brk_prepared"
+      },
+      "depends_on": "*"
     }
   ]
 }

--- a/src/data/brk2.prepare.json
+++ b/src/data/brk2.prepare.json
@@ -8,9 +8,6 @@
   "destination": {
     "application": "GOBPrepare"
   },
-  "publish_schemas": {
-    "brk2_prep": "brk2_prepared"
-  },
   "actions": [
     {
       "type": "clear",
@@ -333,6 +330,14 @@
         "select_tng",
         "select_zrt"
       ]
+    },
+    {
+      "type": "publish_schemas",
+      "id": "publish_schemas",
+      "publish_schemas": {
+        "brk2_prep": "brk2_prepared"
+      },
+      "depends_on": "*"
     }
   ]
 }

--- a/src/data/brp.prepare.json
+++ b/src/data/brp.prepare.json
@@ -2,9 +2,6 @@
   "version": "0.1",
   "name": "BRP",
   "catalogue": "brp",
-  "publish_schemas": {
-    "brp_prep": "brp_prepared"
-  },
   "destination": {
     "application": "GOBPrepare",
     "type": "postgres"
@@ -665,6 +662,14 @@
           }
         ]
       }
+    },
+    {
+      "type": "publish_schemas",
+      "id": "publish_schemas",
+      "publish_schemas": {
+        "brp_prep": "brp_prepared"
+      },
+      "depends_on": "*"
     }
   ]
 }

--- a/src/data/wkpb.prepare.json
+++ b/src/data/wkpb.prepare.json
@@ -8,9 +8,6 @@
   "destination": {
     "application": "GOBPrepare"
   },
-  "publish_schemas": {
-    "wkpb_prep": "wkpb_prepared"
-  },
   "actions": [
     {
       "type": "clear",
@@ -90,6 +87,14 @@
         "select_beperkingen"
       ],
       "id": "select_rel_wkpb_bpg_brk_kot_belast_kadastrale_objecten"
+    },
+    {
+      "type": "publish_schemas",
+      "id": "publish_schemas",
+      "publish_schemas": {
+        "wkpb_prep": "wkpb_prepared"
+      },
+      "depends_on": "*"
     }
   ]
 }

--- a/src/data/woz.prepare.json
+++ b/src/data/woz.prepare.json
@@ -2,9 +2,6 @@
   "version": "0.1",
   "name": "WOZ",
   "catalogue": "woz",
-  "publish_schemas": {
-    "woz_prep": "woz_prepared"
-  },
   "destination": {
     "application": "GOBPrepare"
   },
@@ -201,6 +198,14 @@
           }
         ]
       }
+    },
+    {
+      "type": "publish_schemas",
+      "id": "publish_schemas",
+      "publish_schemas": {
+        "woz_prep": "woz_prepared"
+      },
+      "depends_on": "*"
     }
   ]
 }

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,3 @@
 -e git+https://github.com/Amsterdam/GOB-Config.git@v0.8.0#egg=gobconfig
 -e git+https://github.com/Amsterdam/GOB-Core.git@v2.0.0#egg=gobcore
+pydash==5.1.0

--- a/src/tests/data/test_prepare_definitions.py
+++ b/src/tests/data/test_prepare_definitions.py
@@ -43,7 +43,7 @@ class TestPrepareDefinitions(TestCase):
         actions_done = []
 
         for action in actions:
-            if "depends_on" in action:
+            if "depends_on" in action and action["depends_on"] != "*":
                 for depends_on in action["depends_on"]:
                     self.assertTrue(depends_on in actions_done)
 


### PR DESCRIPTION
'publish_schema' used to be a default action on every prepare definition that was executed in the 'complete_prepare_process' method, called when all tasks were complete.

However, we also need to execute this step from Airflow. This default step is now extracted into its own action. A '*' dependency is added to denote steps that need to happen after all other steps. The _create_tasks method will take this into account and set the necessary dependencies.