### PR TITLE
BRK2 KOT changes. (#405)

### DIFF
--- a/src/data/sql/brk2/kot.remove_duplicate_ontstaan_uit_relations.sql
+++ b/src/data/sql/brk2/kot.remove_duplicate_ontstaan_uit_relations.sql
@@ -1,6 +1,6 @@
 CREATE OR REPLACE FUNCTION brk2_undouble_g_perceel_relations() RETURNS integer AS
 $$
-    -- Removes duplicate relations from is_ontstaan_uit_g_perceel and is_ontstaan_uit_kadastraalobject columns.
+    -- Removes duplicate relations from is_ontstaan_uit_brk_g_perceel and is_ontstaan_uit_brk_kadastraalobject columns.
 -- JSON objects in those columns contain (id, volgnummer, identificatie) combinations because they are
 -- needed in kot.update_a_geometrie.sql. We remove the id and volgnummer attributes from the JSON and undouble
 -- the resulting list of objects with only the 'identificatie' attribute.
@@ -15,7 +15,7 @@ BEGIN
     LOOP
         -- Undouble g_perceel
         UPDATE brk2_prep.kadastraal_object kot
-        SET is_ontstaan_uit_g_perceel=new_relations.new_relation
+        SET is_ontstaan_uit_brk_g_perceel=new_relations.new_relation
         FROM (SELECT id,
                      volgnummer,
                      array_to_json(
@@ -29,8 +29,8 @@ BEGIN
                            kot.volgnummer,
                            gperc ->> 'kot_identificatie' AS kot_identificatie
                     FROM brk2_prep.kadastraal_object kot
-                             JOIN jsonb_array_elements(kot.is_ontstaan_uit_g_perceel) gperc ON TRUE
-                    WHERE kot.is_ontstaan_uit_g_perceel IS NOT NULL
+                             JOIN jsonb_array_elements(kot.is_ontstaan_uit_brk_g_perceel) gperc ON TRUE
+                    WHERE kot.is_ontstaan_uit_brk_g_perceel IS NOT NULL
                       AND kot.id >= current_id
                       AND kot.id < (current_id + batch_size)
                     GROUP BY kot.id, kot.volgnummer, gperc ->> 'kot_identificatie') q
@@ -43,7 +43,7 @@ BEGIN
 
         -- Undouble ontstaan_uit_kadastraalobject
         UPDATE brk2_prep.kadastraal_object kot
-        SET is_ontstaan_uit_kadastraalobject=new_relations.new_relation
+        SET is_ontstaan_uit_brk_kadastraalobject=new_relations.new_relation
         FROM (SELECT id,
                      volgnummer,
                      array_to_json(
@@ -57,8 +57,8 @@ BEGIN
                            kot.volgnummer,
                            gperc ->> 'kot_identificatie' AS kot_identificatie
                     FROM brk2_prep.kadastraal_object kot
-                             JOIN jsonb_array_elements(kot.is_ontstaan_uit_kadastraalobject) gperc ON TRUE
-                    WHERE kot.is_ontstaan_uit_kadastraalobject IS NOT NULL
+                             JOIN jsonb_array_elements(kot.is_ontstaan_uit_brk_kadastraalobject) gperc ON TRUE
+                    WHERE kot.is_ontstaan_uit_brk_kadastraalobject IS NOT NULL
                       AND kot.id >= current_id
                       AND kot.id < (current_id + batch_size)
                     GROUP BY kot.id, kot.volgnummer, gperc ->> 'kot_identificatie') q

--- a/src/data/sql/brk2/kot.set_is_ontstaan_uit_g_perceel.sql
+++ b/src/data/sql/brk2/kot.set_is_ontstaan_uit_g_perceel.sql
@@ -1,7 +1,7 @@
 CREATE INDEX ON brk2_prep.zakelijk_recht(betrokken_bij_appartementsrechtsplitsing_vve);
 
 UPDATE brk2_prep.kadastraal_object kot
-SET is_ontstaan_uit_g_perceel = q.relatie_g_perceel
+SET is_ontstaan_uit_brk_g_perceel = q.relatie_g_perceel
 FROM (select kot.identificatie,
              kot.volgnummer,
              json_agg(

--- a/src/data/sql/brk2/kot.set_is_ontstaan_uit_kadastraalobject.sql
+++ b/src/data/sql/brk2/kot.set_is_ontstaan_uit_kadastraalobject.sql
@@ -1,5 +1,5 @@
 UPDATE brk2_prep.kadastraal_object kot
-SET is_ontstaan_uit_kadastraalobject=q.ontstaan_uit_kadastraalobject
+SET is_ontstaan_uit_brk_kadastraalobject=q.ontstaan_uit_kadastraalobject
 FROM (SELECT kot.id,
              kot.volgnummer,
              array_to_json(
@@ -28,7 +28,7 @@ FROM (SELECT kot.id,
                        zrt_b.__rust_op_kot_volgnummer = ontst_uit_kot.volgnummer
       WHERE kot.indexletter = 'A'
       GROUP BY kot.id, kot.volgnummer) q(kot_id, kot_volgnummer, ontstaan_uit_kadastraalobject)
-WHERE kot.is_ontstaan_uit_kadastraalobject is null
+WHERE kot.is_ontstaan_uit_brk_kadastraalobject is null
   AND kot.indexletter = 'A'
   AND q.kot_id = kot.id
   AND q.kot_volgnummer = kot.volgnummer

--- a/src/data/sql/brk2/kot.update_a_geometrie.sql
+++ b/src/data/sql/brk2/kot.update_a_geometrie.sql
@@ -3,9 +3,9 @@
 --  the geometrie of the verblijfsobject is in the union of related g-percelen
 --
 --  The clause
---  AND kot1.aangeduid_door_kadastralesectie = kot2.aangeduid_door_kadastralesectie
---  AND kot1.aangeduid_door_kadastralegemeentecode_code = kot2.aangeduid_door_kadastralegemeentecode_code
---  was added to filter out G-percelen that are not in the same aangeduid_door_kadastralesectie.
+--  AND kot1.aangeduid_door_brk_kadastralesectie = kot2.aangeduid_door_brk_kadastralesectie
+--  AND kot1.aangeduid_door_brk_kadastralegemeentecode_code = kot2.aangeduid_door_brk_kadastralegemeentecode_code
+--  was added to filter out G-percelen that are not in the same aangeduid_door_brk_kadastralesectie.
 ANALYZE brk2_prep.kadastraal_object;
 ANALYZE bag_brk2.verblijfsobjecten_geometrie;
 
@@ -15,8 +15,8 @@ SELECT kot1.id                  AS id,
        kot1.volgnummer          AS volgnummer,
        ST_Union(kot2.geometrie) AS g_poly
 FROM brk2_prep.kadastraal_object kot1
-         JOIN JSONB_ARRAY_ELEMENTS(kot1.is_ontstaan_uit_g_perceel) AS g_perceel
-              ON kot1.is_ontstaan_uit_g_perceel IS NOT NULL
+         JOIN JSONB_ARRAY_ELEMENTS(kot1.is_ontstaan_uit_brk_g_perceel) AS g_perceel
+              ON kot1.is_ontstaan_uit_brk_g_perceel IS NOT NULL
                   AND g_perceel ->> 'kot_id' IS NOT NULL
          JOIN brk2_prep.kadastraal_object kot2
               ON kot2.id = (g_perceel ->> 'kot_id')::integer
@@ -24,8 +24,8 @@ FROM brk2_prep.kadastraal_object kot1
                   AND kot2._expiration_date IS NULL
 WHERE kot1.indexletter = 'A'
   AND kot1._expiration_date IS NULL
-  AND kot1.aangeduid_door_kadastralesectie = kot2.aangeduid_door_kadastralesectie
-  AND kot1.aangeduid_door_kadastralegemeentecode_code = kot2.aangeduid_door_kadastralegemeentecode_code
+  AND kot1.aangeduid_door_brk_kadastralesectie = kot2.aangeduid_door_brk_kadastralesectie
+  AND kot1.aangeduid_door_brk_kadastralegemeentecode_code = kot2.aangeduid_door_brk_kadastralegemeentecode_code
 GROUP BY kot1.id, kot1.volgnummer;
 
 -- Create index on new table and analyze
@@ -41,8 +41,8 @@ WITH
            kot.volgnummer AS volgnummer,
            vbo.geometrie AS geometrie
         FROM brk2_prep.kadastraal_object kot
-        JOIN jsonb_array_elements(kot.heeft_een_relatie_met_verblijfsobject) AS adres
-            ON kot.heeft_een_relatie_met_verblijfsobject IS NOT NULL
+        JOIN jsonb_array_elements(kot.heeft_een_relatie_met_bag_verblijfsobject) AS adres
+            ON kot.heeft_een_relatie_met_bag_verblijfsobject IS NOT NULL
             AND adres->>'bag_id' IS NOT NULL
         JOIN bag_brk2.verblijfsobjecten_geometrie vbo
             ON adres->>'bag_id' = vbo.identificatie

--- a/src/data/sql/brk2/select.kadastraal_object.sql
+++ b/src/data/sql/brk2/select.kadastraal_object.sql
@@ -6,13 +6,13 @@ SELECT kot.identificatie                    AS identificatie,
        LPAD(kot.index_nummer::text, 4, '0') AS kadastrale_aanduiding,
        kot.akrkadastralegemeentecode || kot.sectie || LPAD(kot.perceelnummer::text, 5, '0') ||
        kot.index_letter                     AS __kadastrale_aanduiding_minus_index_nummer,
-       LPAD(brg.cbscode::text, 4, '0')      AS aangeduid_door_gemeente_code,
-       brg.bgmnaam                          AS aangeduid_door_gemeente_omschrijving,
-       kge.code                             AS aangeduid_door_kadastralegemeente_code,
-       kge.omschrijving                     AS aangeduid_door_kadastralegemeente_omschrijving,
-       kot.akrkadastralegemeentecode_code   AS aangeduid_door_kadastralegemeentecode_code,
-       kot.akrkadastralegemeentecode        AS aangeduid_door_kadastralegemeentecode_omschrijving,
-       kot.sectie                           AS aangeduid_door_kadastralesectie,
+       LPAD(brg.cbscode::text, 4, '0')      AS aangeduid_door_brk_gemeente_code,
+       brg.bgmnaam                          AS aangeduid_door_brk_gemeente_omschrijving,
+       kge.code                             AS aangeduid_door_brk_kadastralegemeente_code,
+       kge.omschrijving                     AS aangeduid_door_brk_kadastralegemeente_omschrijving,
+       kot.akrkadastralegemeentecode_code   AS aangeduid_door_brk_kadastralegemeentecode_code,
+       kot.akrkadastralegemeentecode        AS aangeduid_door_brk_kadastralegemeentecode_omschrijving,
+       kot.sectie                           AS aangeduid_door_brk_kadastralesectie,
        kot.perceelnummer                    AS perceelnummer,
        kot.index_letter                     AS indexletter,
        kot.index_nummer                     AS indexnummer,
@@ -34,8 +34,8 @@ SELECT kot.identificatie                    AS identificatie,
        kot.hoofdsplitsing_identificatie     AS hoofdsplitsing_identificatie,
        kot.afwijking_lijst_rechthebbenden   AS afwijking_lijst_rechthebbenden,
        CASE
-           WHEN kot.soortgrootte_code IN ('2', '5', '6', '7', '8', '9', '10', '11', '12') THEN TRUE
-           ELSE FALSE
+           WHEN kot.soortgrootte_code IN ('2', '5', '6', '7', '8', '9', '10', '11', '12') THEN 'J'
+           ELSE 'N'
            END                              AS indicatie_voorlopige_kadastrale_grens,
        kot.geometrie                        AS geometrie,                       -- later vullen voor A-percelen
        prc.geometrie                        AS plaatscoordinaten,
@@ -59,9 +59,9 @@ SELECT kot.identificatie                    AS identificatie,
                 CASE kot.status_code
                     WHEN 'H' THEN kot.creation
                     END)                    AS _expiration_date,
-       NULL::jsonb                          AS is_ontstaan_uit_g_perceel,       -- later vullen
-       adr.vot_adressen                     AS heeft_een_relatie_met_verblijfsobject,
-       NULL::jsonb                          AS is_ontstaan_uit_kadastraalobject -- later vullen
+       NULL::jsonb                          AS is_ontstaan_uit_brk_g_perceel,       -- later vullen
+       adr.vot_adressen                     AS heeft_een_relatie_met_bag_verblijfsobject,
+       NULL::jsonb                          AS is_ontstaan_uit_brk_kadastraalobject -- later vullen
 FROM brk2.kadastraal_object kot
          LEFT JOIN brk2.kadastraal_object_percnummer prc
                    ON kot.id = prc.kadastraalobject_id AND kot.volgnummer = prc.kadastraalobject_volgnummer
@@ -92,11 +92,11 @@ FROM brk2.kadastraal_object kot
 CREATE INDEX ON brk2_prep.kadastraal_object (id, volgnummer);
 CREATE INDEX ON brk2_prep.kadastraal_object (identificatie, volgnummer);
 CREATE INDEX ON brk2_prep.kadastraal_object (indexletter);
-CREATE INDEX ON brk2_prep.kadastraal_object USING GIN (is_ontstaan_uit_g_perceel);
-CREATE INDEX ON brk2_prep.kadastraal_object USING GIN (is_ontstaan_uit_kadastraalobject);
-CREATE INDEX ON brk2_prep.kadastraal_object USING GIN (heeft_een_relatie_met_verblijfsobject);
-CREATE INDEX ON brk2_prep.kadastraal_object (aangeduid_door_kadastralesectie);
-CREATE INDEX ON brk2_prep.kadastraal_object (aangeduid_door_kadastralegemeentecode_code);
+CREATE INDEX ON brk2_prep.kadastraal_object USING GIN (is_ontstaan_uit_brk_g_perceel);
+CREATE INDEX ON brk2_prep.kadastraal_object USING GIN (is_ontstaan_uit_brk_kadastraalobject);
+CREATE INDEX ON brk2_prep.kadastraal_object USING GIN (heeft_een_relatie_met_bag_verblijfsobject);
+CREATE INDEX ON brk2_prep.kadastraal_object (aangeduid_door_brk_kadastralesectie);
+CREATE INDEX ON brk2_prep.kadastraal_object (aangeduid_door_brk_kadastralegemeentecode_code);
 CREATE INDEX ON brk2_prep.kadastraal_object (__kadastrale_aanduiding_minus_index_nummer);
 CREATE INDEX ON brk2_prep.kadastraal_object (_expiration_date);
 CREATE INDEX ON brk2_prep.kadastraal_object (id);

--- a/src/data/sql/brk2/select.kadastrale_gemeente.sql
+++ b/src/data/sql/brk2/select.kadastrale_gemeente.sql
@@ -11,10 +11,10 @@ FROM (SELECT gc2.identificatie,
       FROM (SELECT gc1.identificatie,
                    gc1.ligt_in_gemeente,
                    ST_UnaryUnion(ST_Collect(gc1.geometrie)) AS geometrie
-            FROM (SELECT aangeduid_door_kadastralegemeente_omschrijving AS identificatie,
-                         (ST_DumpRings(geometrie)).path                 AS nrings,
-                         (ST_DumpRings(geometrie)).geom                 AS geometrie,
-                         _gemeente                                      AS ligt_in_gemeente
+            FROM (SELECT aangeduid_door_brk_kadastralegemeente_omschrijving AS identificatie,
+                         (ST_DumpRings(geometrie)).path                     AS nrings,
+                         (ST_DumpRings(geometrie)).geom                     AS geometrie,
+                         _gemeente                                          AS ligt_in_gemeente
                   FROM brk2_prep.kadastraal_object
                   WHERE indexletter = 'G'
                     AND ST_IsValid(geometrie)

--- a/src/data/sql/brk2/select.kadastrale_gemeentecode.sql
+++ b/src/data/sql/brk2/select.kadastrale_gemeentecode.sql
@@ -11,10 +11,10 @@ FROM (SELECT gc2.identificatie,
       FROM (SELECT gc1.identificatie,
                    gc1.is_onderdeel_van_kadastralegemeente,
                    ST_UnaryUnion(ST_Collect(gc1.geometrie)) AS geometrie
-            FROM (SELECT aangeduid_door_kadastralegemeentecode_omschrijving AS identificatie,
-                         (ST_DumpRings(geometrie)).path                     AS nrings,
-                         (ST_DumpRings(geometrie)).geom                     AS geometrie,
-                         aangeduid_door_kadastralegemeente_omschrijving     AS is_onderdeel_van_kadastralegemeente
+            FROM (SELECT aangeduid_door_brk_kadastralegemeentecode_omschrijving AS identificatie,
+                         (ST_DumpRings(geometrie)).path                         AS nrings,
+                         (ST_DumpRings(geometrie)).geom                         AS geometrie,
+                         aangeduid_door_brk_kadastralegemeente_omschrijving     AS is_onderdeel_van_kadastralegemeente
                   FROM brk2_prep.kadastraal_object
                   WHERE indexletter = 'G'
                     AND ST_IsValid(geometrie)

--- a/src/data/sql/brk2/select.kadastrale_sectie.sql
+++ b/src/data/sql/brk2/select.kadastrale_sectie.sql
@@ -1,9 +1,9 @@
-SELECT aangeduid_door_kadastralegemeentecode_omschrijving || aangeduid_door_kadastralesectie AS identificatie,
-       aangeduid_door_kadastralesectie                                                       AS code,
-       aangeduid_door_kadastralegemeentecode_omschrijving                                    AS is_onderdeel_van_brk_kadastrale_gemeentecode,
-       ST_Union(ST_SnapToGrid(geometrie, 0.0001))                                            AS geometrie
+SELECT aangeduid_door_brk_kadastralegemeentecode_omschrijving || aangeduid_door_brk_kadastralesectie AS identificatie,
+       aangeduid_door_brk_kadastralesectie                                                           AS code,
+       aangeduid_door_brk_kadastralegemeentecode_omschrijving                                        AS is_onderdeel_van_brk_kadastrale_gemeentecode,
+       ST_Union(ST_SnapToGrid(geometrie, 0.0001))                                                    AS geometrie
 FROM brk2_prep.kadastraal_object
 WHERE indexletter = 'G'
   AND ST_IsValid(geometrie)
   AND _expiration_date IS NULL
-GROUP BY aangeduid_door_kadastralegemeentecode_omschrijving, aangeduid_door_kadastralesectie
+GROUP BY aangeduid_door_brk_kadastralegemeentecode_omschrijving, aangeduid_door_brk_kadastralesectie


### PR DESCRIPTION
`indicatie_voorlopige_kadastrale_grens` aangepast naar **J**/**N**.

Tabellen hernoemd:
- `aangeduid_door_gemeente_code` => `aangeduid_door_brk_gemeente_code`
- `aangeduid_door_gemeente_omschrijving` => `aangeduid_door_brk_gemeente_omschrijving`
- `aangeduid_door_kadastralegemeente_code` => `aangeduid_door_brk_kadastralegemeente_code`
- `aangeduid_door_kadastralegemeente_omschrijving` => `aangeduid_door_brk_kadastralegemeente_omschrijving`
- `aangeduid_door_kadastralegemeentecode_code` => `aangeduid_door_brk_kadastralegemeentecode_code`
- `aangeduid_door_kadastralegemeentecode_omschrijving` => `aangeduid_door_brk_kadastralegemeentecode_omschrijving`
- `aangeduid_door_kadastralesectie` => `aangeduid_door_brk_kadastralesectie`
- `is_ontstaan_uit_g_perceel` => `is_ontstaan_uit_brk_g_perceel`
- `heeft_een_relatie_met_verblijfsobject` => `heeft_een_relatie_met_bag_verblijfsobject`
- `is_ontstaan_uit_kadastraalobject` => `is_ontstaan_uit_brk_kadastraalobject`