### PR TITLE
Replace generic ANALYZE calls in BRK1 prepare with specific table ANALYZE calls

### DIFF
--- a/src/data/sql/brk/kot.add_relatie_g_perceel.sql
+++ b/src/data/sql/brk/kot.add_relatie_g_perceel.sql
@@ -11,7 +11,8 @@
 -- In this query we set all direct parent <-> child relation
 
 -- Analyze database first.
-ANALYZE;
+ANALYZE brk_prep.kadastraal_object;
+ANALYZE brk_prep.zakelijk_recht;
 
 CREATE TEMPORARY TABLE kot_ontstaan_uit AS
 SELECT kot.nrn_kot_id,

--- a/src/data/sql/brk/preselect.kot_geo.sql
+++ b/src/data/sql/brk/preselect.kot_geo.sql
@@ -1,5 +1,6 @@
 -- Analyze database first.
-ANALYZE;
+ANALYZE brk_prep.kadastraal_object;
+ANALYZE bag.verblijfsobjecten_geometrie;
 
 --  This SQL statement updates the geometrie for kadastraal_object of type 'A'
 --  end sets it to the geometrie of the first related verblijfsobject if

--- a/src/data/sql/brk2/kot.is_ontstaan_uit_g_perceel.unduplicate.sql
+++ b/src/data/sql/brk2/kot.is_ontstaan_uit_g_perceel.unduplicate.sql
@@ -8,8 +8,8 @@ SELECT kot_id,
                ARRAY_AGG(
                        JSON_BUILD_OBJECT(
                                'kot_identificatie', kot_identificatie
-                           )
-                   ) ORDER BY kot_identificatie
+                           ) ORDER BY kot_identificatie
+                   )
            )::jsonb AS is_ontstaan_uit_brk_g_perceel
 FROM (SELECT kot.kot_id,
              kot.kot_volgnummer,


### PR DESCRIPTION
Because now the ANALYZE calls are keeping locks on tables that aren't of any importance for the script executing the ANALYZE calls.