### PR TITLE
Fixed BRK2 ID conversion CSV separator.

### DIFF
--- a/src/data/brk2.prepare.json
+++ b/src/data/brk2.prepare.json
@@ -136,7 +136,7 @@
         "file_filter": "^brk/Oude_Nieuwe_ids/Conversietabel_BRK1_2_Identificaties.csv$",
         "container": "acceptatie"
       },
-      "separator": ";",
+      "separator": ",",
       "destination": "brk2_prep.import_id_conversion",
       "id": "import_id_conversion_csv",
       "depends_on": [


### PR DESCRIPTION
Ik had de originele CSV omgezet naar een bestand met alleen de eerste miljoen rijen; daarbij was ook de separator gewijzigd.