### PR TITLE
BRK2 was_identificatie column. (#511)

### DIFF
--- a/src/data/brk2.prepare.json
+++ b/src/data/brk2.prepare.json
@@ -137,7 +137,7 @@
         "container": "acceptatie"
       },
       "separator": ",",
-      "destination": "brk2_prep.import_id_conversion",
+      "destination": "brk2_prep.id_conversion",
       "id": "import_id_conversion_csv",
       "depends_on": [
         "clear_schemas"
@@ -219,7 +219,8 @@
       "id": "select_zrt",
       "depends_on": [
         "preselect_zrt_kot",
-        "preselect_zrt_asg"
+        "preselect_zrt_asg",
+        "import_id_conversion_csv"
       ]
     },
     {
@@ -310,7 +311,8 @@
       "id": "select_akt",
       "depends_on": [
         "select_kot",
-        "import_aardaantekening_csv"
+        "import_aardaantekening_csv",
+        "import_id_conversion_csv"
       ]
     },
     {

--- a/src/data/sql/brk2/select.aantekening_kadastraal_object.sql
+++ b/src/data/sql/brk2/select.aantekening_kadastraal_object.sql
@@ -1,5 +1,6 @@
 SELECT atg.identificatie                                               AS identificatie,
        atg.id                                                          AS __neuron_id,
+       idc.ident_oud                                                   AS was_identificatie,
        koa.kadastraalobject_volgnummer                                 AS volgnummer,
        kot.begin_geldigheid                                            AS begin_geldigheid,
        LEAST(kot._expiration_date, atg.einddatum, atg.einddatum_recht) AS eind_geldigheid,
@@ -32,4 +33,5 @@ FROM brk2.aantekening atg
                                ) AS sjt_identificaties
                     FROM brk2.aantekening_betrokkenpersoon abn
                     GROUP BY abn.aantekening_id) abn ON abn.aantekening_id = atg.id
+         LEFT OUTER JOIN brk2_prep.id_conversion idc ON idc.ident_nieuw = atg.identificatie
 ;

--- a/src/data/sql/brk2/select.aantekening_recht.sql
+++ b/src/data/sql/brk2/select.aantekening_recht.sql
@@ -1,5 +1,6 @@
 SELECT atg.id                                            AS neuron_id,
        atg.identificatie                                 AS identificatie,
+       idc.ident_oud                                     AS was_identificatie,
        atg.einddatum_recht                               AS einddatum_recht,
        atg.aardaantekening_code                          AS aard_code,
        aag.omschrijving                                  AS aard_omschrijving,
@@ -36,3 +37,4 @@ FROM brk2.aantekening atg
                                ) AS sjt_identificaties
                     FROM brk2.aantekening_betrokkenpersoon abn
                     GROUP BY abn.aantekening_id) abn ON abn.aantekening_id = atg.id
+         LEFT OUTER JOIN brk2_prep.id_conversion idc ON idc.ident_nieuw = atg.identificatie

--- a/src/data/sql/brk2/select.stukdeel.sql
+++ b/src/data/sql/brk2/select.stukdeel.sql
@@ -1,5 +1,6 @@
 SELECT sdl.id                                                               AS id,
        sdl.identificatie                                                    AS identificatie,
+       idc.ident_oud                                                        AS was_identificatie,
        sdl.aardstukdeel_code                                                AS aard_code,
        asl.omschrijving                                                     AS aard_omschrijving,
        sdl.bedrtransactiesomlev_vlt_code                                    AS bedrag_transactie_valuta,
@@ -102,6 +103,7 @@ FROM brk2.stukdeel sdl
                                    JOIN brk2_prep.zakelijk_recht zrt ON zrt.__ontstaan_uit_asg_id = asg.id
                           GROUP BY asg.stukdeel_identificatie, zrt.identificatie) q
                     GROUP BY q.stukdeel_identificatie) zrt ON sdl.identificatie = zrt.stukdeel_identificatie
+         LEFT OUTER JOIN brk2_prep.id_conversion idc ON idc.ident_nieuw = sdl.identificatie
          JOIN brk2.bestand bsd ON TRUE
 WHERE COALESCE(
                 tng.tng_ids -> 0 -> 'tng_identificatie',

--- a/src/data/sql/brk2/select.tenaamstelling.sql
+++ b/src/data/sql/brk2/select.tenaamstelling.sql
@@ -6,6 +6,7 @@
 SELECT tng.identificatie                                               AS identificatie,
        tng.id                                                          AS neuron_id,
        zrt.volgnummer                                                  AS volgnummer,
+       idc.ident_oud                                                   AS was_identificatie,
        tng.tennamevan_identificatie                                    AS van_brk_kadastraalsubject,
        zrt.begin_geldigheid                                            AS begin_geldigheid,
        LEAST(zrt._expiration_date, atg.einddatum, atg.einddatum_recht) AS eind_geldigheid,
@@ -48,4 +49,5 @@ FROM brk2.tenaamstelling tng
                     WHERE atg.aardaantekening_code = '21'
                     GROUP BY tag.tenaamstelling_id) art ON tng.id = art.tenaamstelling_id
          LEFT JOIN brk2.aantekening atg ON atg.id = art.id
+         LEFT OUTER JOIN brk2_prep.id_conversion idc ON idc.ident_nieuw = tng.identificatie
 WHERE NOT (tng.identificatie = 'NL.IMKAD.Tenaamstelling.AKR2.100000010664394' AND zrt.volgnummer = 1);

--- a/src/data/sql/brk2/select.zakelijk_recht.sql
+++ b/src/data/sql/brk2/select.zakelijk_recht.sql
@@ -19,6 +19,7 @@ WITH akr_codes(aard_code, akr_code) AS (VALUES ('1', 'BK'),
 SELECT zrt_kot.volgnummer                                       AS volgnummer,
        zrt.id                                                   AS __id,
        zrt.identificatie                                        AS identificatie,
+       idc.ident_oud                                            AS was_identificatie,
        bel.belast                                               AS belast_zakelijkerechten,
        blm.is_belast_met                                        AS belast_met_zakelijkerechten,
        ontstaan_uit.ontstaan_uit_brk_zakelijke_rechten::jsonb   AS ontstaan_uit_brk_zakelijke_rechten,
@@ -99,6 +100,7 @@ FROM brk2.zakelijkrecht zrt
                           GROUP BY identificatie, zrt_asg.__betrokken_bij_asg_id) q
                     GROUP BY __betrokken_bij_asg_id) ontstaan_uit
                    ON ontstaan_uit.__betrokken_bij_asg_id = zrt_asg.__ontstaan_uit_asg_id
+         LEFT OUTER JOIN brk2_prep.id_conversion idc ON idc.ident_nieuw = zrt.identificatie
 ;
 
 CREATE INDEX ON brk2_prep.zakelijk_recht (__id);


### PR DESCRIPTION
was_identificatie column for BRK2 collections:

- zakelijkrechten
- tenaamstellingen
- aantekeningenkadastraleobjecten
- aantekeningenrechten
- stukdelen