### PR TITLE
Use iterator during CSV import to prevent oom

### DIFF
--- a/src/gobprepare/importers/csv_importer.py
+++ b/src/gobprepare/importers/csv_importer.py
@@ -1,21 +1,44 @@
 import contextlib
-import http.client
 import tempfile
-import time
-from typing import Optional
-from urllib.error import HTTPError
+from typing import Iterator, Optional
 
+import pandas as pd
 from gobconfig.datastore.config import get_datastore_config
 from gobcore.datastore.factory import DatastoreFactory
 from gobcore.datastore.objectstore import ObjectDatastore
 from gobcore.datastore.sql import SqlDatastore
 from gobcore.exceptions import GOBException
-from pandas import read_csv, NA as pd_NA
-from pandas.io.parsers import TextFileReader
+from pandas import NA as pd_NA
+from pandas import read_csv
 from pandas.errors import ParserError
+from pandas.io.parsers import TextFileReader
 
 from gobprepare.importers.typing import ReadConfig, SqlCsvImporterConfig
 from gobprepare.utils.postgres import create_table_columnar_query
+from gobprepare.utils.requests import retry
+
+
+@contextlib.contextmanager
+def _load_from_objectstore(datastore: ObjectDatastore) -> Iterator[str]:
+    datastore.connect()
+
+    obj_info = next(datastore.query(None), None)
+
+    if obj_info is None:
+        raise GOBException(f"File not found on Objectstore: {datastore.read_config['file_filter']}")
+
+    _, obj = datastore.connection.get_object(
+        container=datastore.container_name, obj=obj_info["name"], resp_chunk_size=100_000_000
+    )
+
+    with tempfile.NamedTemporaryFile(mode="wb", suffix=".csv") as fp:
+        try:
+            for chunk in obj:
+                fp.write(chunk)
+            print(f"File loaded from objectstore: {obj_info['name']}")
+            yield fp.name
+        finally:
+            datastore.disconnect()
 
 
 class SqlCsvImporter:
@@ -26,24 +49,22 @@ class SqlCsvImporter:
 
     CSV_CHUNK_SIZE = 100_000
 
-    def __init__(self, dst_datastore: SqlDatastore, config: SqlCsvImporterConfig) -> None:
+    def __init__(self, dst_datastore: SqlDatastore, config: SqlCsvImporterConfig):
         """Initialise SqlCsvImporter."""
         self._dst_datastore = dst_datastore
         self._destination = config["destination"]
 
-        self._read_config: ReadConfig = config.get("read_config")
-        self._objectstore: str = config.get("objectstore")
-        self._source: str = config.get("source")
-
-        if not bool(self._objectstore) ^ bool(self._source):
-            raise GOBException("Incomplete config. Expecting key 'objectstore' or 'source'")
+        self._read_config: Optional[ReadConfig] = config.get("read_config")
+        self._objectstore: Optional[str] = config.get("objectstore")
+        self._source: Optional[str] = config.get("source")
 
         # Mapping of CSV columns to database columns (default CSV columns will be used if no alternative supplied)
         self._column_names = config.get("column_names", {})
         self._separator = config.get("separator", ",")
         self._encoding = config.get("encoding", "utf-8")
 
-    def _load_csv(self, reader: TextFileReader) -> tuple[list[str], list[tuple[Optional[str]]]]:
+    @retry(MAX_RETRIES, WAIT_RETRY)
+    def _load_csv_chunk(self, reader: TextFileReader, src_path: str) -> Optional[pd.DataFrame]:
         """Load CSV with data.
 
         Download over HTTP if necessary.
@@ -51,63 +72,32 @@ class SqlCsvImporter:
 
         :return:
         """
-        tries = 0
+        try:
+            return reader.get_chunk(self.CSV_CHUNK_SIZE)
+        except StopIteration:
+            return None
+        except ParserError:
+            raise GOBException(f"CSV parsing exception: {src_path}")
 
-        while True:
-            try:
-                df = reader.get_chunk(self.CSV_CHUNK_SIZE)
-            except StopIteration:
-                return [], []
-            except ParserError:
-                raise GOBException(f"Can't parse CSV: {self._source}")
-            except (HTTPError, http.client.HTTPException):
-                tries += 1
-                if tries >= self.MAX_RETRIES:
-                    raise GOBException(f"Problems downloading CSV: {self._source}")
+    def _process_chunk(self, df: pd.DataFrame) -> tuple[list[str], list[tuple[Optional[str]]]]:
+        # Drop empty rows
+        df.dropna(axis="index", how="all", inplace=True)
+        # Replace empty values with None to insert NULL in database
+        df.replace(to_replace=pd_NA, value=None, inplace=True)
 
-                time.sleep(self.WAIT_RETRY)
-            else:
-                # Drop empty rows
-                df.dropna(axis="index", how="all", inplace=True)
-                df.replace(to_replace=pd_NA, value=None, inplace=True)
+        columns = [self._column_names.get(col, col) for col in df if isinstance(col, str)]
+        data = [row for row in zip(*[df[col] for col in df])]
 
-                columns = [self._column_names.get(col, col) for col in df]
-                data = [row for row in zip(*[df[col] for col in df])]
+        return columns, data
 
-                return columns, data
-
-    @contextlib.contextmanager
-    def _load_from_objectstore(self, datastore: ObjectDatastore):
-        datastore.connect()
-
-        obj_info = next(datastore.query(None), None)
-
-        if obj_info is None:
-            raise GOBException(f"File not found on Objectstore: {self._read_config['file_filter']}")
-
-        _, obj = datastore.connection.get_object(
-            container=datastore.container_name,
-            obj=obj_info["name"],
-            resp_chunk_size=100_000_000
-        )
-
-        with tempfile.NamedTemporaryFile(mode="wb", suffix=".csv") as fp:
-            try:
-                for chunk in obj:
-                    fp.write(chunk)
-                print(f"File loaded from objectstore: {obj_info['name']}")
-                yield fp.name
-            finally:
-                datastore.disconnect()
-
-    def _create_destination_table(self, columns: list[str]) -> None:
+    def _create_destination_table(self, columns: list[str]):
         """Create a destination table.
 
         :param columns:
         :return:
         """
-        # This works for Postgres and probably for most SQL databases
-        columndefs = ",".join([f"\"{col}\" TEXT NULL" for col in columns])
+        # Destination is PostgreSQL, which supports TEXT
+        columndefs = ", ".join([f'"{col}" TEXT NULL' for col in columns])
         query = create_table_columnar_query(self._dst_datastore, self._destination, columndefs)
         self._dst_datastore.execute(query)
 
@@ -117,26 +107,24 @@ class SqlCsvImporter:
         :param data:
         :return:
         """
-        return self._dst_datastore.write_rows(self._destination, data)
+        return self._dst_datastore.write_rows(self._destination, data)  # type: ignore
 
     def _import_csv(self, source_path: str) -> int:
         inserted_rows = 0
 
         with read_csv(
             source_path,
+            index_col=False,
             keep_default_na=False,
             na_values="",  # only convert empty strings to NaN
             sep=self._separator,
             dtype=str,  # force string dtypes
             encoding=self._encoding,
-            iterator=True
+            iterator=True,
         ) as reader:
+            while (chunk := self._load_csv_chunk(reader, source_path)) is not None:
+                columns, data = self._process_chunk(chunk)
 
-            while True:
-                columns, data = self._load_csv(reader)
-
-                if not data:
-                    break
                 if not inserted_rows:
                     self._create_destination_table(columns)
 
@@ -152,9 +140,15 @@ class SqlCsvImporter:
 
         :return:
         """
-        if self._objectstore:
+        if self._objectstore and not self._source:
             datastore = DatastoreFactory.get_datastore(get_datastore_config(self._objectstore), self._read_config)
-            with self._load_from_objectstore(datastore) as src_file:
+
+            if not isinstance(datastore, ObjectDatastore):
+                raise GOBException(f"Expected objectstore, got: {type(datastore)}")
+
+            with _load_from_objectstore(datastore) as src_file:
                 return self._import_csv(src_file)
-        else:
+        elif not self._objectstore and self._source:
             return self._import_csv(self._source)
+        else:
+            raise GOBException("Incomplete config. Expecting key 'objectstore' or 'source'")

--- a/src/gobprepare/importers/typing.py
+++ b/src/gobprepare/importers/typing.py
@@ -24,7 +24,7 @@ class ReadConfig(TypedDict):
     file_filter: str
 
 
-class SqlCsvImporterConfig(ActionCommonConfig):
+class SqlCsvImporterConfig(ActionCommonConfig, total=False):
     """SqlCsvImporter action configuration."""
 
     column_names: dict[str, str]
@@ -33,7 +33,7 @@ class SqlCsvImporterConfig(ActionCommonConfig):
     encoding: Literal["utf-8", "iso-8859-1"]
     objectstore: str
     read_config: ReadConfig
-    separator: Literal[";"]
+    separator: Literal[";", ",", "|", "\t"]
     # URL
     source: str
     type: Literal["import_csv"]

--- a/src/gobprepare/prepare_client.py
+++ b/src/gobprepare/prepare_client.py
@@ -188,7 +188,7 @@ class PrepareClient:
         importer = SqlCsvImporter(self._dst_datastore, action)
 
         rows_imported = importer.import_csv()
-        logger.info(f"Imported {rows_imported} rows from CSV to table {action['destination']}")
+        logger.info(f"Imported {rows_imported:,} rows from CSV to table {action['destination']}")
         return rows_imported
 
     def action_create_table(self, action: CreateTableConfig) -> None:

--- a/src/gobprepare/utils/requests.py
+++ b/src/gobprepare/utils/requests.py
@@ -1,4 +1,8 @@
-from typing import Iterator
+import functools
+import http.client
+import time
+from typing import Any, Callable, Iterator, TypeVar
+from urllib.error import HTTPError
 
 import requests
 
@@ -18,3 +22,54 @@ def post_stream(url: str, json: dict[str, str], **kwargs) -> Iterator[bytes]:
     except requests.exceptions.RequestException:
         raise APIException(f"Request failed due to API exception, response code {result.status_code}")
     return result.iter_lines()  # type: ignore[no-any-return]
+
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def retry(max_tries: int, wait: int) -> Callable[[F], F]:  # noqa: C901
+    """
+    Retry `func` a number of times.
+
+    Objective:
+    The 'retry' function is a decorator that can be used to wrap other functions and add retry functionality to them.
+    The objective of this function is to retry a function call a specified number of times with a specified wait time
+     between each try in case of certain exceptions.
+
+    Inputs:
+    - max_tries: an integer representing the maximum number of times the function call should be retried
+    - wait: an integer representing the number of seconds to wait between each retry
+    - func: the function to be wrapped by the decorator
+
+    Flow:
+    1. The 'retry' function takes in the 'max_tries' and 'wait' parameters and returns a decorator function.
+    2. The decorator function takes in the 'func' parameter and returns an inner function.
+    3. The inner function takes in any number of arguments and keyword arguments.
+    4. The inner function tries to call the 'func' with the provided arguments and keyword arguments.
+    5. If the call to 'func' raises an exception of type 'HTTPError' or 'http.client.HTTPException',
+    the inner function increments the 'tries' counter and checks if it has exceeded the 'max_tries' limit.
+    6. If the 'tries' counter has not exceeded the 'max_tries' limit, the inner function waits for
+    the specified 'wait' time and then tries to call 'func' again with the same arguments and keyword arguments.
+    7. If the 'tries' counter has exceeded the 'max_tries' limit, the inner function raises the exception
+    that was caught from the original call to 'func'.
+    8. If the call to 'func' is successful, the inner function returns the result of the call.
+
+    """
+
+    def inner(func: F):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs) -> Any:
+            tries = 0
+            while True:
+                try:
+                    return func(*args, **kwargs)
+                except (HTTPError, http.client.HTTPException):
+                    tries += 1
+                    if tries >= max_tries:
+                        raise
+
+                    time.sleep(wait)
+
+        return wrapper
+
+    return inner

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,3 @@
 gobconfig@git+https://github.com/Amsterdam/GOB-Config.git@v0.9.4
 -e git+https://github.com/Amsterdam/GOB-Core.git@v2.11.1#egg=gobcore
+pandas-stubs~=2.0.1

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,2 @@
 gobconfig@git+https://github.com/Amsterdam/GOB-Config.git@v0.9.4
--e git+https://github.com/Amsterdam/GOB-Core.git@v2.11.0#egg=gobcore
+-e git+https://github.com/Amsterdam/GOB-Core.git@v2.11.1#egg=gobcore

--- a/src/tests/gobprepare/importers/test_csv_importer.py
+++ b/src/tests/gobprepare/importers/test_csv_importer.py
@@ -1,56 +1,34 @@
 import http.client
+from functools import partial
+from io import StringIO
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 from urllib.error import HTTPError
 
+import pandas as pd
+from pandas import read_csv
 from pandas.errors import ParserError
+from pandas.io.parsers import TextFileReader
+from swiftclient import Connection
 
+from gobcore.datastore.sql import SqlDatastore
 from gobcore.exceptions import GOBException
-from gobprepare.importers.csv_importer import SqlCsvImporter, ObjectDatastore
+from gobprepare.importers.csv_importer import SqlCsvImporter, ObjectDatastore, _load_from_objectstore
+from gobprepare.importers.typing import SqlCsvImporterConfig
+from gobprepare.utils.requests import retry
 
 
-@patch("gobprepare.importers.csv_importer.SqlCsvImporter._load_from_objectstore", MagicMock())
+def patch_retry(max_retry, wait, func, self):
+    return retry(max_retry, wait)(partial(func.__wrapped__, self))
+
+
 class TestSqlCsvImporter(TestCase):
-    class MockPandasDataFrame():
-        class MockRow():
-            def __init__(self, vals):
-                self.vals = vals
+    """Test SqlCsvImporter."""
 
-            def tolist(self):
-                return self.vals
-
-        rows = [
-            ['row1col1', 'row1 col 2', 'row1col 3'],
-            ['ro w2c o l1', 'row2 col 2', 'r o w 2 c o l 3'],
-            ['', '', ''],
-            ['row3 col1', 'r o w3 col 2', 'ro w 3 c ol 3'],
-            ['', '', ''],
-            ['', '', ''],
-            ['', '', ''],
-        ]
-        cols = {
-            "col_a": [row[0] for row in rows],
-            "col_b": [row[1] for row in rows],
-            "col_c": [row[2] for row in rows],
-        }
-        columns = cols.keys()
-
-        def __getitem__(self, item):
-            return self.cols[item]
-
-        def iterrows(self):
-            return [
-                (1, self.MockRow(self.rows[0])),
-                (2, self.MockRow(self.rows[1])),
-                (3, self.MockRow(self.rows[2])),
-                (3, self.MockRow(self.rows[3])),
-                (3, self.MockRow(self.rows[4])),
-                (3, self.MockRow(self.rows[5])),
-                (3, self.MockRow(self.rows[6])),
-            ]
-
-    def _setup_importer(self):
-        self.config = {
+    def setUp(self) -> None:
+        self.config_objectstore: SqlCsvImporterConfig = {
+            "id": "cfg_objectstore",
+            "depends_on": ["other_cfg"],
             "type": "import_csv",
             "read_config": {
                 "file_filter": "http://example.com/somefile.csv",
@@ -59,240 +37,229 @@ class TestSqlCsvImporter(TestCase):
             "objectstore": "TheObjectstore"
         }
 
-        self.dst_datastore = MagicMock()
-        self.importer = SqlCsvImporter(self.dst_datastore, self.config)
-
-    def test_init(self):
-        self._setup_importer()
-        self.assertEqual(self.dst_datastore, self.importer._dst_datastore)
-        self.assertEqual(self.importer._load_from_objectstore.return_value, self.importer._source)
-        self.assertEqual(self.config['destination'], self.importer._destination)
-        self.assertEqual(',', self.importer._separator)
-        self.assertEqual({}, self.importer._column_names)
-        self.assertEqual('utf-8', self.importer._encoding)
-
-        self.importer._load_from_objectstore.assert_called_with("TheObjectstore", self.config['read_config'])
-
-    def test_init_source(self):
-        config = {
+        self.config_source: SqlCsvImporterConfig = {
+            "id": "cfg_source",
+            "depends_on": ["other_cfg"],
             "type": "import_csv",
             "destination": "schema.table",
             "source": "the source",
         }
-        self.importer = SqlCsvImporter(MagicMock(), config)
-        self.assertEqual("the source", self.importer._source)
 
-    def test_init_no_objectstore_or_source(self):
-        config = {"destination": "dst"}
+        self.dst_datastore = MagicMock(spec_set=SqlDatastore)
+        self.os_importer = SqlCsvImporter(self.dst_datastore, self.config_objectstore)
+        self.os_importer._load_csv_chunk = patch_retry(2, 0, SqlCsvImporter._load_csv_chunk, self.os_importer)
+        self.url_importer = SqlCsvImporter(self.dst_datastore, self.config_source)
 
-        with self.assertRaises(GOBException):
-            SqlCsvImporter(MagicMock(), config)
+    def test_init(self):
+        assert self.os_importer._dst_datastore == self.dst_datastore
+        assert self.os_importer._destination == self.config_objectstore["destination"]
+        assert self.os_importer._read_config == self.config_objectstore["read_config"]
+        assert self.os_importer._objectstore == self.config_objectstore["objectstore"]
+        assert self.os_importer._source is None
+        assert self.os_importer._column_names == {}
+        assert self.os_importer._separator == ","
+        assert self.os_importer._encoding == "utf-8"
+        
+        assert self.url_importer._dst_datastore == self.dst_datastore
+        assert self.url_importer._destination == self.config_source["destination"]
+        assert self.url_importer._read_config is None
+        assert self.url_importer._objectstore is None
+        assert self.url_importer._column_names == {}
+        assert self.url_importer._separator == ","
+        assert self.url_importer._encoding == "utf-8"
+        assert self.url_importer._source == "the source"
 
     def test_init_non_defaults(self):
-        self._setup_importer()
-        self.config['column_names'] = {'csv_column': 'db_column'}
-        self.config['separator'] = ';'
-        self.config['encoding'] = 'other-encoding'
+        self.config_objectstore["column_names"] = {"csv_column": "db_column"}
+        self.config_objectstore["separator"] = ";"
+        self.config_objectstore["encoding"] = "iso-8859-1"
 
-        importer = SqlCsvImporter(self.dst_datastore, self.config)
-        self.assertEqual(';', importer._separator)
-        self.assertEqual({'csv_column': 'db_column'}, importer._column_names)
-        self.assertEqual('other-encoding', importer._encoding)
+        importer = SqlCsvImporter(self.dst_datastore, self.config_objectstore)
 
-    def test_empty_row(self):
-        self._setup_importer()
-        class MockPandasList:
-            def __init__(self, lst: list):
-                self.lst = lst
+        assert importer._separator == ";"
+        assert importer._column_names == {"csv_column": "db_column"}
+        assert importer._encoding == "iso-8859-1"
 
-            def tolist(self):
-                return self.lst
-
-        testcases = (
-            (MockPandasList([]), True),
-            (MockPandasList([1, 2]), False),
-            (MockPandasList(['', '']), True),
-            (MockPandasList(['', '2']), False),
-            (MockPandasList(['', 0]), False),
+    def test_read_csv(self):
+        df = read_csv(
+            StringIO("col1;col2;col3\nrow1col1;row1 col 2;nan\nro w2c o l1;row2 col 2;\n;;\n"),
+            keep_default_na=False,
+            na_values="",  # only convert empty strings to NaN
+            sep=";",
+            dtype=str,  # force string dtypes
+            encoding="utf-8",
+            index_col=False
         )
+        # expected is transposed
+        expected = [
+            ["row1col1", "ro w2c o l1", "<NA>"],
+            ["row1 col 2", "row2 col 2", "<NA>"],
+            ["nan", "<NA>", "<NA>"]
+        ]
+        assert expected == [[val if pd.notna(val) else "<NA>" for val in df[col]] for col in df]
 
-        for input, output in testcases:
-            self.assertEqual(output, self.importer._is_empty_row(input))
+    def test_load_csv_chunk(self):
+        mock_reader = MagicMock(spec_set=TextFileReader)
+        self.os_importer._column_names = {'col_a': 'db_col_a'}
 
-    @patch("gobprepare.importers.csv_importer.read_csv")
-    def test_load_csv(self, mock_read_csv):
-        self._setup_importer()
-        mock_pandas = self.MockPandasDataFrame()
-        mock_read_csv.return_value = mock_pandas
+        df = pd.DataFrame({
+            "col_a": ["row1col1", "row1 col 2", pd.NA],
+            "col_b": ["ro w2c o l1", "row2 col 2", pd.NA],
+            "col_c": [pd.NA, pd.NA, pd.NA],
+        })
+        mock_reader.get_chunk.side_effect = [df, StopIteration]
 
-        # col_a will be replaced by db_col_a
-        self.importer._column_names = {
-            'col_a': 'db_col_a'
-        }
-        self.importer._encoding = 'the-encoding'
+        result = self.os_importer._load_csv_chunk(mock_reader, "my src")
 
-        result = self.importer._load_csv()
+        mock_reader.get_chunk.assert_called_with(self.os_importer.CSV_CHUNK_SIZE)
 
-        expected_result = {
-            "columns": [
-                {"name": "db_col_a", "max_length": max([len(i) for i in mock_pandas.cols['col_a']])},
-                {"name": "col_b", "max_length": max([len(i) for i in mock_pandas.cols['col_b']])},
-                {"name": "col_c", "max_length": max([len(i) for i in mock_pandas.cols['col_c']])},
-            ],
-            "data": [
-                # Empty rows should not be returned
-                [str(i) for i in mock_pandas.rows[0]],
-                [str(i) for i in mock_pandas.rows[1]],
-                [str(i) for i in mock_pandas.rows[3]],
-            ]
-        }
-        self.assertEqual(expected_result, result)
-        mock_read_csv.assert_called_with(self.importer._source, keep_default_na=False, sep=self.importer._separator, encoding='the-encoding', dtype=str)
+        assert result is df
+        assert self.os_importer._load_csv_chunk(mock_reader, "my src") is None
 
-    @patch("gobprepare.importers.csv_importer.read_csv")
-    def test_load_csv_parser_error(self, mock_read_csv):
-        self._setup_importer()
-        mock_read_csv.side_effect = ParserError()
-        self.importer._source = 'the source'
+    def test_load_csv_parser_error(self):
+        mock_reader = MagicMock(spec_set=TextFileReader)
+        mock_reader.get_chunk.side_effect = ParserError()
 
-        with self.assertRaisesRegex(GOBException, self.importer._source):
-            self.importer._load_csv()
+        with self.assertRaisesRegex(GOBException, "CSV parsing exception: my src"):
+            self.os_importer._load_csv_chunk(mock_reader, "my src")
 
-    @patch("gobprepare.importers.csv_importer.read_csv")
-    def test_load_csv_http_error(self, mock_read_csv):
-        self._setup_importer()
-        mock_read_csv.side_effect = HTTPError("", "", "", "", "")
+    def test_load_csv_http_error(self):
+        mock_reader = MagicMock(spec_set=TextFileReader)
+        mock_reader.get_chunk.side_effect = [
+            HTTPError("My url", 500, "err msg", "", None),
+            http.client.IncompleteRead(partial=b"some bytes object")
+        ] * 3
 
-        self.importer.WAIT_RETRY = 0
-        self.importer._source = 'the source'
+        with self.assertRaises(http.client.IncompleteRead):
+            self.os_importer._load_csv_chunk(mock_reader, "my src")
 
-        with self.assertRaisesRegex(GOBException, self.importer._source):
-            self.importer._load_csv()
+    def test_process_chunk(self):
+        df = pd.DataFrame({
+            "col_a": ["row1col1", "row1 col 2", pd.NA],
+            "col_b": ["ro w2c o l1", "row2 col 2", pd.NA],
+            "col_c": [pd.NA, pd.NA, pd.NA],
+        })
+        self.os_importer._column_names = {"col_a": "col_a_db"}
 
-        mock_read_csv.side_effect = http.client.IncompleteRead(partial=b"some bytes object")
-        with self.assertRaisesRegex(GOBException, self.importer._source):
-            self.importer._load_csv()
-
-    @patch("gobprepare.importers.csv_importer.tempfile.gettempdir", lambda: '/the_tmp_dir')
-    @patch("gobprepare.importers.csv_importer.os.makedirs")
-    def test_tmp_filename(self, mock_makedirs):
-        self._setup_importer()
-        objectstore_filename = 'the/file/on_objectstore/dir/file.ext'
-        expected_tmp_filename = '/the_tmp_dir/the/file/on_objectstore/dir/file.ext'
-        self.assertEqual(expected_tmp_filename, self.importer._tmp_filename(objectstore_filename))
-
-        mock_makedirs.assert_called_with('/the_tmp_dir/the/file/on_objectstore/dir', exist_ok=True)
+        columns, data = self.os_importer._process_chunk(df)
+        assert columns == ["col_a_db", "col_b", "col_c"]
+        assert data == [
+            ('row1col1', 'ro w2c o l1', None),
+            ('row1 col 2', 'row2 col 2', None)
+        ]
 
     @patch("gobprepare.importers.csv_importer.create_table_columnar_query")
     def test_create_destination_table(self, mock_create_table):
-        self._setup_importer()
-        columns = [
-            {"max_length": 20, "name": "col_a"},
-            {"max_length": 19, "name": "col_b"},
-            {"max_length": 8, "name": "col_c"},
-            {"max_length": 8, "name": "col with SpAceS"},
-        ]
-        self.importer._create_destination_table(columns)
+        columns = ["col_a", "col_b", "col_c", "col with SpAceS"]
+        self.os_importer._create_destination_table(columns)
+
         mock_create_table.assert_called_with(
-            self.importer._dst_datastore,
-            self.config['destination'],
-            '"col_a" VARCHAR(25) NULL,"col_b" VARCHAR(24) NULL,'
-            '"col_c" VARCHAR(13) NULL,"col with SpAceS" VARCHAR(13) NULL',
+            self.os_importer._dst_datastore,
+            self.config_objectstore['destination'],
+            '"col_a" TEXT NULL, "col_b" TEXT NULL, "col_c" TEXT NULL, "col with SpAceS" TEXT NULL',
         )
         self.dst_datastore.execute.assert_called_with(mock_create_table.return_value)
 
     def test_import_data(self):
-        self._setup_importer()
-        data = [[1, 2, 3], [4, 4, 2], [2, 4, 5]]
-        self.importer._import_data(data)
-        self.dst_datastore.write_rows.assert_called_with(self.importer._destination, data)
+        data = [("1", "2"), ("3", "4"), ("5", "6")]
+        self.os_importer._import_data(data)
+        self.dst_datastore.write_rows.assert_called_with(self.os_importer._destination, data)
 
-    def test_import_csv(self):
-        self._setup_importer()
-        data = {
-            "columns": [
-                {"max_length": 20, "name": "col_a"},
-                {"max_length": 19, "name": "col_b"},
-                {"max_length": 8, "name": "col_c"},
-            ],
-            "data": [[1, 2, 3], [4, 4, 2], [2, 4, 5]],
-        }
-        self.importer._load_csv = MagicMock(return_value=data)
-        self.importer._create_destination_table = MagicMock()
-        self.importer._import_data = MagicMock()
+    @patch("gobprepare.importers.csv_importer.read_csv")
+    def test__import_csv(self, mock_read_csv):
+        columns = ["col_a", "col_b", "col_c"]
+        data = [(1, 2, 3), (4, 4, 2), (2, 4, 5)]
+        df = pd.DataFrame(data, columns=columns)
 
-        result = self.importer.import_csv()
-        self.assertEqual(3, result)
-        self.importer._load_csv.assert_called_once()
-        self.importer._create_destination_table.assert_called_with(data['columns'])
-        self.importer._import_data.assert_called_with(data['data'])
+        self.os_importer._load_csv_chunk = MagicMock(side_effect=[df, None])
+        self.os_importer._create_destination_table = MagicMock()
+        self.os_importer._import_data = MagicMock(return_value=len(data))
 
+        result = self.os_importer._import_csv("my source")
 
-class TestSqlCsvImporterLoad(TestCase):
+        assert result == 3
+        assert self.os_importer._load_csv_chunk.call_count == 2
+        self.os_importer._load_csv_chunk.assert_called_with(
+            mock_read_csv.return_value.__enter__.return_value, "my source"
+        )
+        self.dst_datastore.execute.assert_called_with("ANALYZE schema.table")
 
-    @patch("gobprepare.importers.csv_importer.SqlCsvImporter._tmp_filename")
+        self.os_importer._create_destination_table.assert_called_with(columns)
+        self.os_importer._import_data.assert_called_with(data)
+
+        mock_read_csv.assert_called_with(
+            "my source",
+            index_col=False,
+            keep_default_na=False,
+            na_values="",
+            sep=self.os_importer._separator,
+            dtype=str,
+            encoding=self.os_importer._encoding,
+            iterator=True
+        )
+
+    @patch("gobprepare.importers.csv_importer._load_from_objectstore")
     @patch("gobprepare.importers.csv_importer.DatastoreFactory")
     @patch("gobprepare.importers.csv_importer.get_datastore_config")
-    @patch("builtins.open")
-    def test_load_from_objectstore(self, mock_open, mock_get_config, mock_factory, mock_tmp_filename):
-        config = {
-            "type": "import_csv",
-            "read_config": {
-                "file_filter": "http://example.com/somefile.csv",
-            },
-            "destination": "schema.table",
-            "objectstore": "TheObjectstore"
-        }
-        dst_datastore = MagicMock()
-        mock_connection = MagicMock()
-        mock_connection.get_object.return_value = [{}, 'the object data']
-        mock_factory.get_datastore.return_value = MagicMock(spec=ObjectDatastore)
-        mock_factory.get_datastore.return_value.container_name = "my container base"
-        mock_factory.get_datastore.return_value.connection = mock_connection
-        mock_factory.get_datastore.return_value.query.return_value = iter([{'name': 'file/location/on/objectstore.ext'}])
+    def test_import_csv(self, mock_get_config, mock_factory, mock_load_os):
+        mock_factory.get_datastore.return_value = MagicMock(spec_set=ObjectDatastore)
 
-        importer = SqlCsvImporter(dst_datastore, config)
-        importer._tmp_filename = MagicMock()
+        self.os_importer._import_csv = MagicMock()
 
-        mock_connection.get_object.assert_called_with("my container base", 'file/location/on/objectstore.ext')
-        mock_get_config.assert_called_with('TheObjectstore')
-        mock_factory.get_datastore.assert_called_with(mock_get_config.return_value, config['read_config'])
+        self.os_importer.import_csv()
 
-        mock_open.return_value.__enter__.return_value.write.assert_called_with('the object data')
-        self.assertEqual(mock_tmp_filename.return_value, importer._source)
+        mock_get_config.assert_called_with(self.os_importer._objectstore)
+        mock_factory.get_datastore.assert_called_with(mock_get_config.return_value, self.os_importer._read_config)
 
-    @patch("gobprepare.importers.csv_importer.DatastoreFactory")
-    @patch("gobprepare.importers.csv_importer.get_datastore_config", MagicMock())
-    def test_load_from_objectstore_not_found(self, mock_factory):
-        mock_factory.get_datastore.return_value = MagicMock()
-        config = {
-            "type": "import_csv",
-            "read_config": {
-                "file_filter": "http://example.com/somefile.csv",
-            },
-            "destination": "schema.table",
-            "objectstore": "TheObjectstore"
-        }
+        mock_load_os.assert_called_with(mock_factory.get_datastore.return_value)
+        self.os_importer._import_csv.assert_called_with(mock_load_os.return_value.__enter__.return_value)
 
-        mock_factory.get_datastore.return_value = MagicMock(spec=ObjectDatastore)
-        mock_factory.get_datastore.return_value.query.return_value = iter([])
+        # exception on wrong datastore type
+        mock_factory.get_datastore.return_value = type("OtherClass", (object, ), {})()
+        with self.assertRaisesRegex(GOBException, "OtherClass"):
+            self.os_importer.import_csv()
 
-        with self.assertRaises(GOBException):
-            SqlCsvImporter(MagicMock(), config)
+        # other sources (url)
+        mock_load_os.reset_mock()
+        self.url_importer._import_csv = MagicMock()
+        self.url_importer.import_csv()
+        self.url_importer._import_csv.assert_called_with(self.url_importer._source)
+        mock_load_os.assert_not_called()
 
-    @patch("gobprepare.importers.csv_importer.DatastoreFactory")
-    @patch("gobprepare.importers.csv_importer.get_datastore_config", MagicMock())
-    def test_load_from_objectstore_invalid_store(self, mock_factory):
-        mock_factory.get_datastore.return_value = MagicMock()
-        config = {
-            "type": "import_csv",
-            "read_config": {
-                "file_filter": "http://example.com/somefile.csv",
-            },
-            "destination": "schema.table",
-            "objectstore": "TheObjectstore"
-        }
+        # config exception
+        with self.assertRaisesRegex(GOBException, "Incomplete config."):
+            SqlCsvImporter(self.dst_datastore, {"destination": "dst"}).import_csv()
 
-        with self.assertRaisesRegex(AssertionError, "Expected Objectstore"):
-            SqlCsvImporter(MagicMock(), config)
+    @patch("gobprepare.importers.csv_importer.tempfile")
+    def test_load_from_objectstore(self, mock_tmpfile):
+        mock_datastore = MagicMock(spec=ObjectDatastore)
+        mock_datastore.container_name = "my container base"
+        mock_datastore.query.return_value = iter([{"name": "file/location/on/objectstore.ext"}])
 
+        mock_datastore.connection = MagicMock(spec=Connection)
+        mock_datastore.connection.get_object.return_value = {}, ["the object data"]
+
+        mock_tmpfile.NamedTemporaryFile.return_value.__enter__.return_value.name = "my src file"
+
+        with _load_from_objectstore(mock_datastore) as src_file:
+            assert src_file == "my src file"
+
+        mock_tmpfile.NamedTemporaryFile.assert_called_with(mode="wb", suffix=".csv")
+        mock_tmpfile.NamedTemporaryFile.return_value.__enter__.return_value.write.assert_called_with("the object data")
+
+        mock_datastore.connect.assert_called()
+        mock_datastore.disconnect.assert_called()
+        mock_datastore.connection.get_object.assert_called_with(
+            container="my container base",
+            obj="file/location/on/objectstore.ext",
+            resp_chunk_size=100_000_000
+        )
+
+    def test_load_from_objectstore_not_found(self):
+        mock_datastore = MagicMock(spec=ObjectDatastore)
+        mock_datastore.query.return_value = iter([])
+        mock_datastore.read_config = {"file_filter": "http://example.com/somefile.csv"}
+
+        with self.assertRaisesRegex(GOBException, "http://example.com/somefile.csv"):
+            with _load_from_objectstore(mock_datastore) as src_file:
+                pass


### PR DESCRIPTION
Problem: A 2gb csv file causes OOM, because its copied during processing.

- Use chunks when reading csv files
- refactor `_load_from_objectstore` from import csv class and use as contextmanager
- refactor `retry` function to request.utils 
- Remove temporary file after import
- Use Postgres' `TEXT` type instead of `VARCHAR` to omit calculating max length of column values
- `ANALYZE` table after import