### PR TITLE
Feature/78028 gob prepare import handels register dumps (#525)

### DIFF
--- a/src/data/hr.prepare.json
+++ b/src/data/hr.prepare.json
@@ -1,0 +1,194 @@
+{
+    "version": "0.1",
+    "name": "HR",
+    "catalogue": "hr",
+    "destination": {
+        "application": "GOBPrepare"
+    },
+    "actions": [
+        {
+            "type": "clear",
+            "schemas": [
+                "hr",
+                "hr_prep"
+            ],
+            "id": "clear_schemas"
+        },
+        {
+            "type": "import_dump",
+            "objectstore": "HandelsregisterObjectstore",
+            "read_config": {
+                "file_filter": "mks-dump/kvkadr.sql.gz",
+                "container": "handelsregister",
+                "filter_list": "GRANT|DROP|OWNER|search_path|REVOKE|CREATE TRIGGER|CREATE INDEX|ADD CONSTRAINT|ALTER TABLE|PRIMARY KEY \\(",
+                "substitution": {
+                    "igp_[a-zA-Z0-9_]+_cmg_owner": "hr",
+                    "(geopunt(.*?)\\.geometry\\(Point(.*?)\n)": "geopunt public.geometry(POINT,28992)"
+                },
+                "comments_regexp": "(?m)^\\s*--.*$|(^\/*.*?\\*\\$)",
+                "split_regexp": ";\\n|^\\.\n'",
+                "data_delimiter_regexp": "\\.\n",
+                "copy_query_regex": "COPY.*FROM stdin;"
+            },
+            "destination": "hr.kvkadrm00",
+            "id": "import_kvkadr_sql",
+            "depends_on": [
+                "clear_schemas"
+            ]
+        },
+        {
+            "type": "import_dump",
+            "objectstore": "HandelsregisterObjectstore",
+            "read_config": {
+                "file_filter": "mks-dump/kvkmac.sql.gz",
+                "container": "handelsregister",
+                "filter_list": "GRANT|DROP|OWNER|search_path|REVOKE|CREATE TRIGGER|CREATE INDEX|ADD CONSTRAINT|ALTER TABLE|PRIMARY KEY \\(",
+                "substitution": {
+                    "igp_[a-zA-Z0-9_]+_cmg_owner": "hr",
+                    "(geopunt(.*?)\\.geometry\\(Point(.*?)\n)": "geopunt public.geometry(POINT,28992)"
+                },
+                "comments_regexp": "(?m)^\\s*--.*$|(^\/*.*?\\*\\$)",
+                "split_regexp": ";\\n|^\\.\n'",
+                "data_delimiter_regexp": "\\.\n",
+                "copy_query_regex": "COPY.*FROM stdin;"
+            },
+            "destination": "hr.kvkmacm00",
+            "id": "import_kvkmac_sql",
+            "depends_on": [
+                "clear_schemas"
+            ]
+        },
+        {
+            "type": "import_dump",
+            "objectstore": "HandelsregisterObjectstore",
+            "read_config": {
+                "file_filter": "mks-dump/kvkves.sql.gz",
+                "container": "handelsregister",
+                "filter_list": "GRANT|DROP|OWNER|search_path|REVOKE|CREATE TRIGGER|CREATE INDEX|ADD CONSTRAINT|ALTER TABLE|PRIMARY KEY \\(",
+                "substitution": {
+                    "igp_[a-zA-Z0-9_]+_cmg_owner": "hr",
+                    "(geopunt(.*?)\\.geometry\\(Point(.*?)\n)": "geopunt public.geometry(POINT,28992)"
+                },
+                "comments_regexp": "(?m)^\\s*--.*$|(^\/*.*?\\*\\$)",
+                "split_regexp": ";\\n|^\\.\n'",
+                "data_delimiter_regexp": "\\.\n",
+                "copy_query_regex": "COPY.*FROM stdin;"
+            },
+            "destination": "hr.kvvesm00",
+            "id": "import_kvkves_sql",
+            "depends_on": [
+                "clear_schemas"
+            ]
+        },
+        {
+            "type": "import_dump",
+            "objectstore": "HandelsregisterObjectstore",
+            "read_config": {
+                "file_filter": "mks-dump/kvkveshis.sql.gz",
+                "container": "handelsregister",
+                "filter_list": "GRANT|DROP|OWNER|search_path|REVOKE|CREATE TRIGGER|CREATE INDEX|ADD CONSTRAINT|ALTER TABLE|PRIMARY KEY \\(",
+                "substitution": {
+                    "igp_[a-zA-Z0-9_]+_cmg_owner": "hr",
+                    "(geopunt(.*?)\\.geometry\\(Point(.*?)\n)": "geopunt public.geometry(POINT,28992)"
+                },
+                "comments_regexp": "(?m)^\\s*--.*$|(^\/*.*?\\*\\$)",
+                "split_regexp": ";\\n|^\\.\n'",
+                "data_delimiter_regexp": "\\.\n",
+                "copy_query_regex": "COPY.*FROM stdin;"
+            },
+            "destination": "hr.kvkveshism00",
+            "id": "import_kvkveshis_sql",
+            "depends_on": [
+                "clear_schemas"
+            ]
+        },
+        {
+            "type": "import_dump",
+            "objectstore": "HandelsregisterObjectstore",
+            "read_config": {
+                "file_filter": "mks-dump/kvkprs.sql.gz",
+                "container": "handelsregister",
+                "filter_list": "GRANT|DROP|OWNER|search_path|REVOKE|CREATE TRIGGER|CREATE INDEX|ADD CONSTRAINT|ALTER TABLE|PRIMARY KEY \\(",
+                "substitution": {
+                    "igp_[a-zA-Z0-9_]+_cmg_owner": "hr",
+                    "(geopunt(.*?)\\.geometry\\(Point(.*?)\n)": "geopunt public.geometry(POINT,28992)"
+                },
+                "comments_regexp": "(?m)^\\s*--.*$|(^\/*.*?\\*\\$)",
+                "split_regexp": ";\\n|^\\.\n'",
+                "data_delimiter_regexp": "\\.\n",
+                "copy_query_regex": "COPY.*FROM stdin;"
+            },
+            "destination": "hr.kvkprsm00",
+            "id": "import_kvkprs_sql",
+            "depends_on": [
+                "clear_schemas"
+            ]
+        },
+        {
+            "type": "import_dump",
+            "objectstore": "HandelsregisterObjectstore",
+            "read_config": {
+                "file_filter": "mks-dump/kvkprsash.sql.gz",
+                "container": "handelsregister",
+                "filter_list": "GRANT|DROP|OWNER|search_path|REVOKE|CREATE TRIGGER|CREATE INDEX|ADD CONSTRAINT|ALTER TABLE|PRIMARY KEY \\(",
+                "substitution": {
+                    "igp_[a-zA-Z0-9_]+_cmg_owner": "hr",
+                    "(geopunt(.*?)\\.geometry\\(Point(.*?)\n)": "geopunt public.geometry(POINT,28992)"
+                },
+                "comments_regexp": "(?m)^\\s*--.*$|(^\/*.*?\\*\\$)",
+                "split_regexp": ";\\n|^\\.\n'",
+                "data_delimiter_regexp": "\\.\n",
+                "copy_query_regex": "COPY.*FROM stdin;"
+            },
+            "destination": "hr.kvkashm00",
+            "id": "import_kvkash_sql",
+            "depends_on": [
+                "clear_schemas"
+            ]
+        },
+        {
+            "type": "import_dump",
+            "objectstore": "HandelsregisterObjectstore",
+            "read_config": {
+                "file_filter": "mks-dump/kvkbeshdn.sql.gz",
+                "container": "handelsregister",
+                "filter_list": "GRANT|DROP|OWNER|search_path|REVOKE|CREATE TRIGGER|CREATE INDEX|ADD CONSTRAINT|ALTER TABLE|PRIMARY KEY \\(",
+                "substitution": {
+                    "igp_[a-zA-Z0-9_]+_cmg_owner": "hr",
+                    "(geopunt(.*?)\\.geometry\\(Point(.*?)\n)": "geopunt public.geometry(POINT,28992)"
+                },
+                "comments_regexp": "(?m)^\\s*--.*$|(^\/*.*?\\*\\$)",
+                "split_regexp": ";\\n|^\\.\n'",
+                "data_delimiter_regexp": "\\.\n",
+                "copy_query_regex": "COPY.*FROM stdin;"
+            },
+            "destination": "hr.kvkbeshdnm00",
+            "id": "import_kvkbeshdn_sql",
+            "depends_on": [
+                "clear_schemas"
+            ]
+        },
+        {
+            "type": "import_dump",
+            "objectstore": "HandelsregisterObjectstore",
+            "read_config": {
+                "file_filter": "mks-dump/kvkhdn.sql.gz",
+                "container": "handelsregister",
+                "filter_list": "GRANT|DROP|OWNER|search_path|REVOKE|CREATE TRIGGER|CREATE INDEX|ADD CONSTRAINT|ALTER TABLE|PRIMARY KEY \\(",
+                "substitution": {
+                    "igp_[a-zA-Z0-9_]+_cmg_owner": "hr",
+                    "(geopunt(.*?)\\.geometry\\(Point(.*?)\n)": "geopunt public.geometry(POINT,28992)"
+                },
+                "comments_regexp": "(?m)^\\s*--.*$|(^\/*.*?\\*\\$)",
+                "split_regexp": ";\\n|^\\.\n'",
+                "data_delimiter_regexp": "\\.\n",
+                "copy_query_regex": "COPY.*FROM stdin;"
+            },
+            "destination": "hr.kvkhdnm00",
+            "id": "import_kvkhdn_sql",
+            "depends_on": [
+                "clear_schemas"
+            ]
+        }
+    ]
+}

--- a/src/gobprepare/importers/dump_importer.py
+++ b/src/gobprepare/importers/dump_importer.py
@@ -1,0 +1,134 @@
+import contextlib
+import re
+import tempfile
+from gzip import GzipFile
+from io import StringIO
+from typing import Iterator, Optional
+
+from gobconfig.datastore.config import get_datastore_config
+from gobcore.datastore.factory import DatastoreFactory
+from gobcore.datastore.objectstore import ObjectDatastore
+from gobcore.datastore.postgres import PostgresDatastore
+from gobcore.exceptions import GOBException
+from gobcore.logging.logger import logger
+
+from gobprepare.importers.typing import ReadConfig, SqlDumpImporterConfig
+
+
+@contextlib.contextmanager
+def _load_from_objectstore(datastore: ObjectDatastore) -> Iterator[str]:
+    datastore.connect()
+    try:
+        obj_info = next(datastore.query(None))
+    except StopIteration:
+        raise GOBException(f"File '{datastore.read_config['file_filter']}' not found on Objectstore.")
+    else:
+        _, obj = datastore.connection.get_object(
+            container=datastore.container_name, obj=obj_info["name"], resp_chunk_size=100_000_000
+        )
+
+    with tempfile.NamedTemporaryFile(mode="wb", suffix=".gz") as fp:
+        try:
+            for chunk in obj:
+                fp.write(chunk)
+            logger.info(f"File loaded from objectstore: {obj_info['name']}")
+            yield fp.name
+        finally:
+            datastore.disconnect()
+
+
+class SqlDumpImporter:
+    """Import a SQL dump into a PostgresDatastore table."""
+
+    def __init__(self, dst_datastore: PostgresDatastore, config: SqlDumpImporterConfig) -> None:
+        """Initialise SqlDumpImporter."""
+        self._dst_datastore = dst_datastore
+        self._encoding = config.get("encoding", "utf-8")
+        self._read_config: ReadConfig = config["read_config"]
+        self._objectstore: Optional[str] = config.get("objectstore")
+
+    def _perform_query_substitutions(self, query: str) -> str:
+        # perform the substitutions as listed in read_config.
+        if not query.endswith(self._read_config["data_delimiter_regexp"]):
+            query += ";"
+            for pattern, replacement in self._read_config["substitution"].items():
+                query = re.sub(pattern, replacement, query)
+        return query
+
+    def _insert_data(self, copy_query: str, data: str) -> None:
+        # ignore the data delimiter '\.'
+        data_to_insert = data.split(self._read_config["data_delimiter_regexp"])
+        if len(data_to_insert[0]) != 0:
+            self._dst_datastore.copy_from_stdin(copy_query, StringIO(data_to_insert[0]))
+
+    def _process_and_execute_queries(self, queries: list[str]) -> None:
+        """Filter out and perform substitution using lists in read_config.
+
+        then execute the queries.
+
+        :return: None
+        """
+        filter_list_pattern = re.compile(self._read_config["filter_list"])
+        copy_query_pattern = re.compile(self._read_config["copy_query_regex"])
+        data_delimiter_pattern = re.compile(self._read_config["data_delimiter_regexp"])
+
+        for query in queries:
+            # remove leading new line '\n\n'
+            query = query.lstrip()
+            if query and not re.match(filter_list_pattern, query):
+                query = self._perform_query_substitutions(query)
+                # the copy query (insert) is in the form: COPY <table name> (colomn1, colomn 2, ...) FROM stdin;
+                # the copy query is always followed by the data in the form:
+                #       "100000000008718135	Vennoot;	100000000008718134	100000000008718136	OnbeperktBevoegd	0
+                #       100000000008718135	Vennoot	100000000008718134	100000000008718136	OnbeperktBevoegd	0
+                #       \."
+                # extract the copy query and execute it in the next iteration with the to insert data.
+                if re.match(copy_query_pattern, query):
+                    copy_query = query
+                    continue
+
+                # extract and insert data using copy_query.
+                if re.search(data_delimiter_pattern, query):
+                    data = query
+                    self._insert_data(copy_query, data)
+                    continue
+
+                # execute other (regular) queries
+                self._dst_datastore.execute(query)
+
+    def _extract_sql_queries(self, content):
+        # remove all comments and other non-executable lines (e.g empty lines and None resulting from split() action).
+        lines = re.split(self._read_config["comments_regexp"], content)
+        for line in lines:
+            if line is not None and line.strip():
+                yield line
+
+    def _import_dump(self, source_path: str) -> str:
+        with GzipFile(source_path, "r") as fp:
+            file_content = fp.read().decode("utf-8")
+        logger.info(f'Processing decompressed content of dump "{self._read_config["file_filter"].split("/")[-1]}"')
+
+        sql_queries = self._extract_sql_queries(file_content)
+        split_pattern = re.compile(self._read_config["split_regexp"])
+
+        for query_list in sql_queries:
+            # split on ';' for the sql queries en on '\.' for the data
+            queries = re.split(split_pattern, query_list)
+            self._process_and_execute_queries(queries)
+
+        return self._read_config["file_filter"].split("/")[-1]
+
+    def import_dump(self) -> str:
+        """Entry method. Return (processed) gz file name.
+
+        :return: str
+        """
+        if self._objectstore:
+            datastore = DatastoreFactory.get_datastore(get_datastore_config(self._objectstore), self._read_config)
+
+            if not isinstance(datastore, ObjectDatastore):
+                raise GOBException(f"Expected objectstore, got: {type(datastore)}")
+            with _load_from_objectstore(datastore) as src_dump_file:
+                return self._import_dump(src_dump_file)
+        else:
+            raise GOBException("Incomplete config. Expecting key 'objectstore'")

--- a/src/gobprepare/importers/typing.py
+++ b/src/gobprepare/importers/typing.py
@@ -3,7 +3,6 @@
 See GOB-Prepare/src/data/*.json
 """
 
-
 from typing import Literal, TypedDict
 
 from gobprepare.typing import ActionCommonConfig, SQLBaseConfig
@@ -22,6 +21,13 @@ class ReadConfig(TypedDict):
     """Read file configuration."""
 
     file_filter: str
+    container: str
+    filter_list: str
+    substitution: dict[str, str]
+    comments_regexp: str
+    split_regexp: str
+    data_delimiter_regexp: str
+    copy_query_regex: str
 
 
 class SqlCsvImporterConfig(ActionCommonConfig, total=False):
@@ -37,3 +43,15 @@ class SqlCsvImporterConfig(ActionCommonConfig, total=False):
     # URL
     source: str
     type: Literal["import_csv"]
+
+
+class SqlDumpImporterConfig(ActionCommonConfig, total=False):
+    """SqlDumpImporter action configuration."""
+
+    description: str
+    destination: str
+    encoding: Literal["utf-8", "iso-8859-1"]
+    objectstore: str
+    read_config: ReadConfig
+    source: str
+    type: Literal["import_sqlDump"]

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,3 @@
-gobconfig@git+https://github.com/Amsterdam/GOB-Config.git@v0.9.6
--e git+https://github.com/Amsterdam/GOB-Core.git@v2.11.2#egg=gobcore
+gobconfig@git+https://github.com/Amsterdam/GOB-Config.git@v0.10.0
+-e git+https://github.com/Amsterdam/GOB-Core.git@v2.13.1#egg=gobcore
 pandas-stubs~=2.0.1

--- a/src/tests/gobprepare/importers/test_dump_import.py
+++ b/src/tests/gobprepare/importers/test_dump_import.py
@@ -1,0 +1,171 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+import pandas as pd
+from swiftclient import Connection
+
+from gobcore.datastore.sql import SqlDatastore
+from gobcore.datastore.postgres import PostgresDatastore
+from gobcore.exceptions import GOBException
+from gobprepare.importers.dump_importer import SqlDumpImporter, ObjectDatastore, _load_from_objectstore
+from gobprepare.importers.typing import SqlDumpImporterConfig
+
+class TestSqlDumpImporter(TestCase):
+    """Test SqlDumpImporter."""
+
+    def setUp(self) -> None:
+        self.config_objectstore: SqlDumpImporterConfig = {
+            "id": "cfg_objectstore",
+            "depends_on": ["other_cfg"],
+            "type": "import_dump",
+            "read_config": {
+                "file_filter": "http://example.com/somefile.sql.gz",
+                "container": "some_container",
+                "filter_list": "STRING1|STRING2|STRING3|string4",
+                "substitution": {
+                    "OLD_SCHEMA_NAME": "NEW_SCHEMA_NAME",
+                    "pattern_2": "replace_2"
+                },
+                "comments_regexp": "(?m)^\\s*--.*$",
+                "split_regexp": ";\\n|^\\.\n'",
+                "data_delimiter_regexp": "\\.\n",
+                "copy_query_regex": "COPY.*FROM stdin;"
+            },
+            "destination": "schema.table",
+            "objectstore": "TheObjectstore"
+        }
+        self.query = "CREATE TABLE OLD_SCHEMA_NAME.someTable (id numeric(18,0) NOT NULL, name character varying(20))"
+        self.copy_query = "COPY schema.sometable (colomn1, colomn 2, colomn3, colomn4) FROM stdin;"
+        self.data_input = "value1	value2	value3	value4\nvalue5	value6	value7	value8\n"
+
+        self.dst_datastore = MagicMock(spec_set=PostgresDatastore)
+        self.os_importer = SqlDumpImporter(self.dst_datastore, self.config_objectstore)
+
+    def test_init(self):
+        assert self.os_importer._dst_datastore == self.dst_datastore
+        assert self.os_importer._encoding == "utf-8"
+        assert self.os_importer._read_config == self.config_objectstore["read_config"]
+        assert self.os_importer._objectstore == self.config_objectstore["objectstore"]
+
+    @patch("gobprepare.importers.dump_importer.logger")
+    @patch("gobprepare.importers.dump_importer.tempfile")
+    def test_load_from_objectstore(self, mock_tmpfile, mock_logger):
+        mock_datastore = MagicMock(spec=ObjectDatastore)
+        mock_datastore.container_name = "my container base"
+        mock_datastore.query.return_value = iter([{"name": "file/location/on/objectstore.ext"}])
+
+        mock_datastore.connection = MagicMock(spec=Connection)
+        mock_datastore.connection.get_object.return_value = {}, ["the dump object"]
+
+        mock_tmpfile.NamedTemporaryFile.return_value.__enter__.return_value.name = "my src file"
+
+        with _load_from_objectstore(mock_datastore) as src_file:
+            assert src_file == "my src file"
+        mock_logger.info.assert_called_once()
+
+        mock_tmpfile.NamedTemporaryFile.assert_called_with(mode="wb", suffix=".gz")
+        mock_tmpfile.NamedTemporaryFile.return_value.__enter__.return_value.write.assert_called_with("the dump object")
+
+        mock_datastore.connect.assert_called()
+        mock_datastore.disconnect.assert_called()
+        mock_datastore.connection.get_object.assert_called_with(
+            container="my container base",
+            obj="file/location/on/objectstore.ext",
+            resp_chunk_size=100_000_000
+        )
+
+    def test_load_from_objectstore_not_found(self):
+        mock_datastore = MagicMock(spec=ObjectDatastore)
+        mock_datastore.query.return_value = iter([])
+        mock_datastore.read_config = {"file_filter": "http://example.com/somefile.sql.gz"}
+
+        with self.assertRaisesRegex(GOBException, "http://example.com/somefile.sql.gz"):
+            with _load_from_objectstore(mock_datastore) as src_file:
+                pass
+
+    @patch("gobprepare.importers.dump_importer._load_from_objectstore")
+    @patch("gobprepare.importers.dump_importer.DatastoreFactory")
+    @patch("gobprepare.importers.dump_importer.get_datastore_config")
+    def test_import_dump(self, mock_get_config, mock_factory, mock_load_os):
+        mock_factory.get_datastore.return_value = MagicMock(spec_set=ObjectDatastore)
+        self.os_importer._read_config == self.config_objectstore["read_config"]
+        self.os_importer._import_dump = MagicMock()
+
+        self.os_importer.import_dump()
+
+        mock_get_config.assert_called_with(self.os_importer._objectstore)
+        # mock_factory.get_datastore.assert_called_with(mock_get_config.return_value, self.config_objectstore["read_config"])
+
+        mock_load_os.assert_called_with(mock_factory.get_datastore.return_value)
+        self.os_importer._import_dump.assert_called_with(mock_load_os.return_value.__enter__.return_value)
+
+        # exception on wrong datastore type
+        mock_factory.get_datastore.return_value = type("OtherClass", (object, ), {})()
+        with self.assertRaisesRegex(GOBException, "OtherClass"):
+            self.os_importer.import_dump()
+
+        # config exception
+        with self.assertRaisesRegex(GOBException, "Incomplete config. Expecting key 'objectstore'"):
+            SqlDumpImporter(self.dst_datastore, {"read_config": {
+                "file_filter": "http://example.com/somefile.sql.gz"}}).import_dump()
+
+    @patch("gobprepare.importers.dump_importer.logger")
+    @patch("gobprepare.importers.dump_importer.GzipFile")
+    def test__import_dump(self, mock_GzipFile, mock_logger):
+        file_path = "path/to/somefile.sql.gz"
+        expected_content = "Content of the file"
+
+        self.os_importer._extract_sql_queries = MagicMock(return_value=self.query)
+        self.os_importer._process_and_execute_queries = MagicMock()
+
+        mock_decompressed_file = mock_GzipFile.return_value
+        mock_decompressed_file.read.return_value.decode.return_value = expected_content
+
+        result = self.os_importer._import_dump(file_path)
+        self.assertEqual(result, "somefile.sql.gz")
+        mock_GzipFile.assert_called_with(file_path, 'r')
+        mock_logger.info.assert_called_once()
+
+    def test_extract_sql_queries(self):
+        dump_with_comment = """
+        --
+        -- this is a comment line; With extra comment; Schema: igp_pgplup_cmg_owner; Owner: igp_pgplup_cmg_owner
+        --
+        CREATE TABLE OLD_SCHEMA_NAME.someTable (id numeric(18,0) NOT NULL, name character varying(20));
+        """
+        expected_query = "\n        CREATE TABLE OLD_SCHEMA_NAME.someTable (id numeric(18,0) NOT NULL, name character varying(20));\n        "
+
+        sql_queries = self.os_importer._extract_sql_queries(dump_with_comment)
+        result = next(query for query in sql_queries)
+
+        self.assertEqual(result, expected_query)
+
+    def test_perform_query_substituions(self):
+        expected_query = "CREATE TABLE NEW_SCHEMA_NAME.someTable (id numeric(18,0) NOT NULL, name character varying(20));"
+
+        result = self.os_importer._perform_query_substitutions(self.query)
+        self.assertEqual(result, expected_query)
+
+    @patch("gobprepare.importers.dump_importer.StringIO")
+    def test_insert_data(self, mock_io):
+        test_data ="value1	value2	value3	value4\nvalue5	value6	value7	value8\n\\.\n"
+        self.dst_datastore.copy_from_stdin.return_value = None
+        self.os_importer._insert_data(self.copy_query, test_data)
+
+        self.dst_datastore.copy_from_stdin.assert_called_with(self.copy_query, mock_io.return_value)
+        mock_io.assert_called_with(self.data_input)
+
+    @patch("gobprepare.importers.dump_importer.StringIO")
+    def test_process_and_execute_queries(self, mock_io):
+        queries = [
+            "ANALYZE schema.table",
+            "COPY schema.sometable (colomn1, colomn 2, colomn3, colomn4) FROM stdin",
+            "value1	value2	value3	value4\nvalue5	value6	value7	value8\n\\.\n"]
+        other_query = "ANALYZE schema.table;"
+
+        self.dst_datastore.copy_from_stdin.return_value = None
+        self.os_importer._process_and_execute_queries(queries)
+
+        self.dst_datastore.copy_from_stdin.assert_called_with(self.copy_query, mock_io.return_value)
+        mock_io.assert_called_with(self.data_input)
+        self.dst_datastore.copy_from_stdin.assert_called_once()
+        self.dst_datastore.execute.assert_called_with(other_query)


### PR DESCRIPTION
Alle sql dumps (op objectstore) worden opgehaald, ingelezen en in hr database verwerkt(behalve kvkveshis.sql.gz)

    'kvkadr.sql.gz', 
    'kvkbeshdn.sql.gz',
    'kvkhdn.sql.gz',
    'kvkmac.sql.gz',
    'kvkprs.sql.gz',
    'kvkprsash.sql.gz',
    'kvkves.sql.gz',
    'kvkveshis.sql.gz',

De dump “kvkveshis.sql.gz” wordt wel opgehaald maar niet goed verwerkt. Het bestand bevat wel sql queries maar geen data. Dus het zou alleen een lege tabel moeten aanmaken maar na unzippen is de content leeg. het nog naar deze issue gekeken.

De sql dump worden uitgefilterd en alle sql queries die in de filter lijst voorkomen worden verwijdert en niet uitgevoerd. De lijst van de te filteren worden is:
_GRANT
DROP
OWNER
search_path
REVOKE
CREATE TRIGGER
CREATE INDEX
ADD CONSTRAINT
ALTER TABLE
PRIMARY KEY (_
Deze lijst komt overeen met de lijst uit de oude HR implementatie.

NP: In de sql dump zit ook een “ CREATE UNIQUE INDEX” statement, maar deze wordt niet uitgefilterd. ==> Discussie punt.
Voorbeeld: “ CREATE UNIQUE INDEX kvkveshisml1 ON
igp_pgplup_cmg_owner.kvkveshism00 USING btree (vestigingsnummer, kvknummer);”

Er wordt nog geen volgorde gehouden bij het verwerken van de dumps. Er wordt niet gekeken naar de afhankelijkheden tussen de tabellen. ==> Discussie punt.

Er worden niet gekeken naar de laatste update van de dumps en dus niet gekeken hoe oud de files zijn.De dumps die in de objectstore staan worden op opgehaald en verwerkt. Met job scheduler kan bepaald worden hoe vaak dienen de dumps verwerk worden. ==> Discussie punt

NP: Unittests zijn nog niet compleet!