### PR TITLE
Revert "Vacuum after updating kot_geo table"

### DIFF
--- a/src/data/sql/brk/preselect.kot_geo.sql
+++ b/src/data/sql/brk/preselect.kot_geo.sql
@@ -122,6 +122,3 @@ WHERE brk_prep.kot_geo.nrn_kot_id = near_a_poly.nrn_kot_id
   AND brk_prep.kot_geo.nrn_kot_volgnr = near_a_poly.nrn_kot_volgnr
   AND brk_prep.kot_geo.geometrie IS NULL
 ;
-
--- lots of updates
-VACUUM ANALYZE brk_prep.kot_geo;

--- a/src/data/sql/brk2/preselect.kot_geo.sql
+++ b/src/data/sql/brk2/preselect.kot_geo.sql
@@ -108,6 +108,3 @@ WHERE brk2_prep.kot_geo.id = near_a_poly.id
   AND brk2_prep.kot_geo.volgnummer = near_a_poly.volgnummer
   AND brk2_prep.kot_geo.geometrie IS NULL
 ;
-
--- lots of updates
-VACUUM ANALYZE brk2_prep.kot_geo;


### PR DESCRIPTION
This reverts commit 048ae57c426c4ab2472cbcd2ce84c64ccf6df717.

Can't vacuum here, not in autocommit mode.