### PR TITLE
fix multiple ffv id's in NNP en NP and table names changed

### DIFF
--- a/src/data/hr.prepare.json
+++ b/src/data/hr.prepare.json
@@ -233,7 +233,7 @@
     },
     {
       "type": "execute_sql",
-      "description": "Create HR natuurlijkepersonen. table",
+      "description": "Create HR natuurlijkepersonen table",
       "id": "create_hr_nps",
       "query_src": "file",
       "query": "data/sql/hr/create.natuurlijkepersonen.sql",

--- a/src/data/hr.prepare.json
+++ b/src/data/hr.prepare.json
@@ -212,20 +212,20 @@
     },
     {
       "type": "execute_sql",
-      "description": "Create HR functievervulling table",
+      "description": "Create HR functievervullingen table",
       "id": "create_hr_fvv",
       "query_src": "file",
-      "query": "data/sql/hr/create.functievervulling.sql",
+      "query": "data/sql/hr/create.functievervullingen.sql",
       "depends_on": [
         "import_kvkprsash"
       ]
     },
     {
       "type": "execute_sql",
-      "description": "Create HR nietnatuurlijkpersoon table",
+      "description": "Create HR nietnatuurlijkepersonen table",
       "id": "create_hr_nnp",
       "query_src": "file",
-      "query": "data/sql/hr/create.niet_natuurlijk_persoon.sql",
+      "query": "data/sql/hr/create.niet_natuurlijkepersonen.sql",
       "depends_on": [
         "import_kvkprs",
         "import_kvkprsash"
@@ -233,10 +233,10 @@
     },
     {
       "type": "execute_sql",
-      "description": "Create HR natuurlijkpersoon. table",
+      "description": "Create HR natuurlijkepersonen. table",
       "id": "create_hr_nps",
       "query_src": "file",
-      "query": "data/sql/hr/create.natuurlijkpersoon.sql",
+      "query": "data/sql/hr/create.natuurlijkepersonen.sql",
       "depends_on": [
         "import_kvkprs",
         "import_kvkprsash"

--- a/src/data/sql/hr/create.functievervullingen.sql
+++ b/src/data/sql/hr/create.functievervullingen.sql
@@ -1,4 +1,4 @@
-CREATE TABLE hr_prep.functievervulling AS
+CREATE TABLE hr_prep.functievervullingen AS
 
   SELECT
     fvv.ashid::varchar                                          AS identificatie,

--- a/src/data/sql/hr/create.functievervullingen.sql
+++ b/src/data/sql/hr/create.functievervullingen.sql
@@ -24,7 +24,7 @@ CREATE TABLE hr_prep.functievervullingen AS
     NULL::jsonb                                                 AS gemachtigde,
     NULL::boolean                                               AS volmacht,
     NULL::boolean                                               AS statutair,
-    NULL::jsonb                                                 AS heeft_hr_vestiging, -- relaties VES
+    NULL::jsonb                                                 AS heeft_hr_vestigingen, -- relaties VES
     NULL::boolean                                               AS beperkte_volmacht,
     NULL::boolean                                               AS beperking_in_geld,
     NULL::boolean                                               AS doen_van_opgave_aan_handelsregister,

--- a/src/data/sql/hr/create.maatschappelijke_activiteiten.sql
+++ b/src/data/sql/hr/create.maatschappelijke_activiteiten.sql
@@ -14,7 +14,7 @@ CREATE TABLE hr_prep.maatschappelijke_activiteiten AS
     ves.hoofdvestiging_nummer                                   AS heeft_hoofdvestiging,
     ves.datumaanvang::text::date                                AS datum_aanvang_maatschappelijke_activiteit_vestiging,
     ves.datumeinde::text::date                                  AS datum_einde_maatschappelijke_activiteit_vestiging,
-    tves.wordt_uitgeoefend_in_ncv                               AS wordt_uitgeoefend_in_niet_commerciele_vestiging,
+    tves.wordt_uitgeoefend_in_ncv                               AS wordt_uitgeoefend_in_niet_commerciele_vestigingen,
     CASE -- heeft_als_eigenaar_np; prsid bij gebrek aan BSN (nps.bsn)
       WHEN nps.typering = 'natuurlijkPersoon' THEN nps.prsid::varchar
       ELSE NULL
@@ -31,7 +31,7 @@ CREATE TABLE hr_prep.maatschappelijke_activiteiten AS
     NULL::date                                                  AS datum_einde_onderneming,
     NULL                                                        AS is_overdracht_voortzetting_onderneming,
     NULL::date                                                  AS datum_overdracht_voortzetting_onderneming,
-    tves.wordt_uitgeoefend_in_cvs                               AS wordt_uitgeoefend_in_commerciele_vestiging,
+    tves.wordt_uitgeoefend_in_cvs                               AS wordt_uitgeoefend_in_commerciele_vestigingen,
     NULL::date                                                  AS datum_aanvang_onderneming_vestiging,
     NULL::date                                                  AS datum_einde_onderneming_vestiging,
     NULL::date                                                  AS datum_aanvang_onderneming_handelsnaam,

--- a/src/data/sql/hr/create.natuurlijkepersonen.sql
+++ b/src/data/sql/hr/create.natuurlijkepersonen.sql
@@ -1,4 +1,4 @@
- CREATE TABLE hr_prep.natuurlijkpersoon AS
+ CREATE TABLE hr_prep.natuurlijkepersonen AS
 
   SELECT
     nps.prsid::varchar                                                  AS identificatie,
@@ -24,8 +24,8 @@
     nps.rol                                                             AS rol,
     nps.toegangscode::varchar                                           AS toegangscode,
     nps.nummer::integer                                                 AS nummer,
-    fvh.ashid::varchar                                                  AS heeft_functie_vervulling, -- altijd leeg
-    fvi.ashid::varchar                                                  AS is_functie_vervulling
+    fvh.ashid                                                           AS heeft_functie_vervullingen, -- altijd leeg
+    fvi.ashid                                                           AS is_functie_vervullingen
 
   FROM (
     hr.kvkprsm00
@@ -51,6 +51,23 @@
     ) AS sub USING(prsid)
   ) AS nps
 
-  LEFT JOIN hr.kvkprsashm00 fvh ON nps.prsid = fvh.prsidh
-  LEFT JOIN hr.kvkprsashm00 fvi ON nps.prsid = fvi.prsidi
+  LEFT JOIN (
+    SELECT
+      JSONB_AGG(ashid) AS ashid,
+      prsidh 
+    FROM
+      hr.kvkprsashm00
+    GROUP BY
+      prsidh
+    ) AS fvh ON nps.prsid = fvh.prsidh
+  LEFT JOIN (
+    SELECT
+      JSONB_AGG(ashid) as ashid,
+      prsidi
+    FROM
+      hr.kvkprsashm00
+    GROUP BY
+      prsidi
+    ) AS fvi ON nps.prsid = fvi.prsidi
+
   WHERE typering = 'natuurlijkPersoon'

--- a/src/data/sql/hr/create.niet_natuurlijkepersonen.sql
+++ b/src/data/sql/hr/create.niet_natuurlijkepersonen.sql
@@ -1,4 +1,4 @@
-CREATE TABLE hr_prep.nietnatuurlijkpersoon AS
+CREATE TABLE hr_prep.niet_natuurlijkepersonen AS
 
   SELECT
     nnp.prsid::varchar                                                  AS identificatie,
@@ -24,13 +24,30 @@ CREATE TABLE hr_prep.nietnatuurlijkpersoon AS
     nnp.rol::varchar                                                    AS rol,
     NULL::date                                                          AS datum_aanvang,
     NULL::date                                                          AS datum_einde,
-    hfvv.ashid                                                          AS heeft_functie_vervulling,
-    ifvv.ashid                                                          AS is_functie_vervulling
+    hfvv.ashid                                                          AS heeft_functie_vervullingen,
+    ifvv.ashid                                                          AS is_functie_vervullingen
 
   FROM
     hr.kvkprsm00 nnp
-    LEFT JOIN hr.kvkprsashm00 hfvv ON nnp.prsid = hfvv.prsidh
-    LEFT JOIN hr.kvkprsashm00 ifvv ON nnp.prsid = ifvv.prsidi
+
+  LEFT JOIN (
+    SELECT
+      JSONB_AGG(ashid) AS ashid,
+      prsidh 
+    FROM
+      hr.kvkprsashm00
+    GROUP BY
+      prsidh
+  ) AS hfvv ON nnp.prsid = hfvv.prsidh
+  LEFT JOIN (
+    SELECT
+      JSONB_AGG(ashid) as ashid,
+      prsidi
+    FROM
+      hr.kvkprsashm00
+    GROUP BY
+      prsidi
+  ) AS ifvv ON nnp.prsid = ifvv.prsidi
 
   WHERE
     typering != 'natuurlijkPersoon'

--- a/src/data/sql/hr/create.vestigingen.sql
+++ b/src/data/sql/hr/create.vestigingen.sql
@@ -106,7 +106,7 @@ CREATE TABLE hr_prep.vestigingen AS
       )
     END                                                                 AS domeinnamen,
 
-    NULL                                                                AS is_samengevoegd_met_vestiging,
+    NULL                                                                AS is_samengevoegd_met_vestigingen,
     NULL::date                                                          AS datum_afgesloten,
     NULL::date                                                          AS datum_samenvoeging,
     ves.naam                                                            AS naam,


### PR DESCRIPTION
- `heeft_functie_vervullingen` en `is_functie_vervullingen` kolommen in natuurlijkepersonen en niet_natuurlijkepersonen zijn aangepast zodat deze een array van de functievervullingen (id's) zullen bevatten.
Deze is de fix voor het probleem dat prisd niet uniek is in NNP tabel.

- sommige tabel namen zijn aangepast om de consistentie in GOB code te behouden. 