### PR TITLE
Verify number of rows in result tables. (#577)

### DIFF
--- a/src/gobprepare/typing.py
+++ b/src/gobprepare/typing.py
@@ -92,3 +92,12 @@ class PublishSchemasConfig(TypedDict):
     id: str
     publish_schemas: dict[str, str]
     type: Literal["publish_schemas"]
+
+
+class RowCountConfig(ActionCommonConfig):
+    """Check table row counts action configuration."""
+
+    description: str
+    table_row_counts: dict[str, int]
+    margin_percentage: int
+    type: Literal["check_row_counts"]

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,3 @@
-gobconfig@git+https://github.com/Amsterdam/GOB-Config.git@v0.14.0
--e git+https://github.com/Amsterdam/GOB-Core.git@v2.19.1#egg=gobcore
+gobconfig@git+https://github.com/Amsterdam/GOB-Config.git@v0.14.1
+-e git+https://github.com/Amsterdam/GOB-Core.git@v2.20.0#egg=gobcore
 pandas-stubs~=2.0.2

--- a/src/tests/gobprepare/test_prepare_client.py
+++ b/src/tests/gobprepare/test_prepare_client.py
@@ -1,8 +1,9 @@
 from unittest import TestCase
-from unittest.mock import MagicMock, patch, call, mock_open, ANY
+from unittest.mock import MagicMock, call, mock_open, patch
 
 from gobcore.exceptions import GOBException
-from gobprepare.prepare_client import PrepareClient, OracleDatastore, SqlDatastore
+
+from gobprepare.prepare_client import OracleDatastore, PrepareClient, SqlDatastore
 from gobprepare.utils.exceptions import DuplicateTableError
 from tests import fixtures
 
@@ -484,6 +485,33 @@ class TestPrepareClient(TestCase):
             call('src a', 'dst a'),
             call('src b', 'dst b'),
         ])
+
+    def test_run_prepare_action_check_row_counts(self, mock_logger):
+        """Test PrepareClient.action_check_row_counts."""
+        prepare_client = PrepareClient(self.mock_dataset, self.mock_msg)
+        action = {
+            "type": "check_row_counts",
+            'id': 'action_id',
+            "table_row_counts": {"ok_table": 100, "growing_table": 500},
+            "margin_percentage": 5
+        }
+
+        prepare_client._dst_datastore.table_count = MagicMock(side_effect=[104, 509])
+        result = prepare_client._run_prepare_action(action)
+        prepare_client._dst_datastore.table_count.assert_has_calls([
+            call("ok_table"), call("growing_table")
+        ])
+        self.assertEqual(result["action"], "check_row_counts")
+        self.assertEqual(result["id"], "action_id")
+        self.assertTrue(result["row_count_check"])
+
+        prepare_client._dst_datastore.table_count.side_effect=[96, 400]
+        result = prepare_client._run_prepare_action(action)
+        prepare_client._dst_datastore.table_count.assert_has_calls([
+            call("ok_table"), call("growing_table")
+        ])
+        self.assertFalse(result["row_count_check"])
+        mock_logger.error.assert_called_with("Deviation of -20.00% for growing_table! Expected 500 rows, got 400")
 
     def test_get_result(self, mock_logger):
         prepare_client = PrepareClient(self.mock_dataset, self.mock_msg)


### PR DESCRIPTION
Depends on new `PostgresDatastore.table_count` function in GOB-Core.