### PR TITLE
Use `brk2_prep` schema instead of `brk2` for certain tasks

### DIFF
--- a/src/data/brk2.prepare.json
+++ b/src/data/brk2.prepare.json
@@ -2,9 +2,6 @@
   "version": "0.1",
   "name": "BRK2",
   "catalogue": "brk2",
-  "source": {
-    "application": "Neuron"
-  },
   "destination": {
     "application": "GOBPrepare"
   },
@@ -12,7 +9,6 @@
     {
       "type": "clear",
       "schemas": [
-        "brk2",
         "brk2_prep"
       ],
       "id": "clear_schemas"
@@ -27,7 +23,7 @@
       ],
       "query_src": "string",
       "destination_table": {
-        "name": "brk2.bestand",
+        "name": "brk2_prep.bestand",
         "create": true,
         "columns": [
           {
@@ -48,7 +44,7 @@
     {
       "type": "import_csv",
       "source": "https://developer.kadaster.nl/schemas/waardelijsten/BurgemKadgemSectie/BurgemKadgemSectie.csv",
-      "destination": "brk2.import_burgerlijke_gemeentes",
+      "destination": "brk2_prep.import_burgerlijke_gemeentes",
       "id": "import_burgerlijke_gemeentes",
       "depends_on": [
         "clear_schemas"
@@ -81,7 +77,7 @@
     {
       "type": "import_csv",
       "source": "https://developer.kadaster.nl/schemas/waardelijsten/AardAantekening/AardAantekening.csv",
-      "destination": "brk2.import_aardaantekening",
+      "destination": "brk2_prep.import_aardaantekening",
       "column_names": {
         "Code": "code",
         "Waarde": "omschrijving",
@@ -147,6 +143,7 @@
       "query": "data/sql/brk2/preselect.kot.geldigheid.sql",
       "id": "select_kot_geldigheid",
       "depends_on": [
+        "clear_schemas",
         "import_burgerlijke_gemeentes",
         "create_baghulptabel"
       ]

--- a/src/data/brk2.prepare.json
+++ b/src/data/brk2.prepare.json
@@ -14,34 +14,6 @@
       "id": "clear_schemas"
     },
     {
-      "type": "select",
-      "source": "src",
-      "query": [
-        "         SELECT TRUNC(MAX(BSD.DATUM_AANGEMAAKT)) AS brk_bsd_toestandsdatum",
-        "         ,      'Toestandsdatum, d.i. de laatste aanmaakdatum van de BRK-berichten in de naar DIVA gerepliceerde BRK-levering.' AS omschrijving",
-        "           FROM   G0363_BRK2MON.BESTAND BSD"
-      ],
-      "query_src": "string",
-      "destination_table": {
-        "name": "brk2_prep.bestand",
-        "create": true,
-        "columns": [
-          {
-            "name": "brk_bsd_toestandsdatum",
-            "type": "TIMESTAMP"
-          },
-          {
-            "name": "omschrijving",
-            "type": "VARCHAR(120)"
-          }
-        ]
-      },
-      "depends_on": [
-        "clear_schemas"
-      ],
-      "id": "create_bestand_table"
-    },
-    {
       "type": "import_csv",
       "source": "https://developer.kadaster.nl/schemas/waardelijsten/BurgemKadgemSectie/BurgemKadgemSectie.csv",
       "destination": "brk2_prep.import_burgerlijke_gemeentes",

--- a/src/data/brk2.prepare.json
+++ b/src/data/brk2.prepare.json
@@ -310,6 +310,7 @@
       "query": "data/sql/brk2/select.kadastraal_subject.sql",
       "id": "select_sjt",
       "depends_on": [
+        "select_meta",
         "create_view_subject_actueel",
         "select_tng",
         "select_zrt"
@@ -353,6 +354,7 @@
       "query": "data/sql/brk2/select.stukdeel.sql",
       "id": "select_sdl",
       "depends_on": [
+        "select_meta",
         "select_art",
         "select_akt",
         "select_tng",

--- a/src/data/sql/brk2/materialized_view.baghulptabel.sql
+++ b/src/data/sql/brk2/materialized_view.baghulptabel.sql
@@ -1,4 +1,4 @@
-CREATE MATERIALIZED VIEW brk2.baghulptabel AS
+CREATE MATERIALIZED VIEW brk2_prep.baghulptabel AS
 SELECT kadastraalobject_id,
        kadastraalobject_volgnummer,
        JSONB_AGG(

--- a/src/data/sql/brk2/select.aantekening_kadastraal_object.sql
+++ b/src/data/sql/brk2/select.aantekening_kadastraal_object.sql
@@ -20,7 +20,7 @@ FROM brk2.aantekening atg
          JOIN brk2.kadastraal_object_aantekening koa ON koa.aantekening_identificatie = atg.identificatie
     -- Filter all aantekeningen based on aardaantekening != Aantekening PB
     -- https://dev.azure.com/CloudCompetenceCenter/Datateam%20Basis%20en%20Kernregistraties/_workitems/edit/17723
-         JOIN (SELECT * FROM brk2.import_aardaantekening aag WHERE aag.type != 'Aantekening PB') aag
+         JOIN (SELECT * FROM brk2_prep.import_aardaantekening aag WHERE aag.type != 'Aantekening PB') aag
               ON atg.aardaantekening_code = aag.code
          JOIN brk2_prep.kadastraal_object kot
               ON kot.id = koa.kadastraalobject_id AND

--- a/src/data/sql/brk2/select.kadastraal_object.sql
+++ b/src/data/sql/brk2/select.kadastraal_object.sql
@@ -62,7 +62,7 @@ FROM brk2.kadastraal_object kot
          LEFT JOIN brk2.c_kadastralegemeente kge
                    ON kot.kadastralegemeente_code = kge.code
          LEFT JOIN (SELECT "CBSCode", "BGMNaam", "KadGemNaam"
-                    FROM brk2.import_burgerlijke_gemeentes
+                    FROM brk2_prep.import_burgerlijke_gemeentes
                     GROUP BY "CBSCode", "BGMNaam", "KadGemNaam") brg
                    ON kge.omschrijving = brg."KadGemNaam"
          LEFT JOIN brk2.c_soortgrootte sge
@@ -71,7 +71,7 @@ FROM brk2.kadastraal_object kot
                    ON kot.cultuurcodeonbebouwd_code = cod.code
          LEFT JOIN brk2.c_cultuurcodebebouwd ccb
                    ON kot.cultuurcodebebouwd_code = ccb.code
-         LEFT JOIN brk2.baghulptabel adr
+         LEFT JOIN brk2_prep.baghulptabel adr
                    ON adr.kadastraalobject_id = kot.id AND adr.kadastraalobject_volgnummer = kot.volgnummer
          LEFT JOIN (SELECT koo.kadastraalobject_id,
                            koo.kadastraalobject_volgnummer,

--- a/src/data/sql/brk2/select.kadastraal_subject.sql
+++ b/src/data/sql/brk2/select.kadastraal_subject.sql
@@ -153,5 +153,5 @@ FROM subjecten sjt
          LEFT JOIN brk2.c_land lbu ON (obu.land_code = lbu.code)
          LEFT JOIN brk2.c_land pbu ON (pau.land_code = pbu.code)
          LEFT JOIN brk2_prep.subject_expiration_date ede ON sjt.Identificatie_subject = ede.subject_id
-         JOIN brk2.bestand bsd ON TRUE
+         JOIN brk2_prep.bestand bsd ON TRUE
 ;

--- a/src/data/sql/brk2/select.kadastraal_subject.sql
+++ b/src/data/sql/brk2/select.kadastraal_subject.sql
@@ -135,7 +135,7 @@ SELECT sjt.Identificatie_subject            AS identificatie,
        pbl.woonplaatsnaam                   AS postadres_postbus_woonplaatsnaam,
        ede.expiration_date                  AS datum_actueel_tot,
        ede.expiration_date                  AS _expiration_date,
-       bsd.brk_bsd_toestandsdatum           AS toestandsdatum
+       meta.toestandsdatum                  AS toestandsdatum
 FROM subjecten sjt
          LEFT JOIN brk2.objectlocatie_binnenland obd ON (sjt.woonlocatie_identificatie = obd.identificatie)
          LEFT JOIN brk2.objectlocatie_buitenland obu ON (sjt.woonlocatie_identificatie = obu.identificatie)
@@ -153,5 +153,5 @@ FROM subjecten sjt
          LEFT JOIN brk2.c_land lbu ON (obu.land_code = lbu.code)
          LEFT JOIN brk2.c_land pbu ON (pau.land_code = pbu.code)
          LEFT JOIN brk2_prep.subject_expiration_date ede ON sjt.Identificatie_subject = ede.subject_id
-         JOIN brk2.bestand bsd ON TRUE
+         JOIN brk2_prep.meta meta ON TRUE
 ;

--- a/src/data/sql/brk2/select.kadastraal_subject.sql
+++ b/src/data/sql/brk2/select.kadastraal_subject.sql
@@ -153,5 +153,5 @@ FROM subjecten sjt
          LEFT JOIN brk2.c_land lbu ON (obu.land_code = lbu.code)
          LEFT JOIN brk2.c_land pbu ON (pau.land_code = pbu.code)
          LEFT JOIN brk2_prep.subject_expiration_date ede ON sjt.Identificatie_subject = ede.subject_id
-         JOIN brk2_prep.bestand bsd ON TRUE
+         JOIN brk2.bestand bsd ON TRUE
 ;

--- a/src/data/sql/brk2/select.meta.sql
+++ b/src/data/sql/brk2/select.meta.sql
@@ -1,5 +1,5 @@
-SELECT
-    1 as id,
-    bsd.brk_bsd_toestandsdatum as toestandsdatum,
-    bsd.omschrijving
+SELECT 1                                                                                                               AS id,
+       DATE_TRUNC('DAY', MAX(bsd.datum_aangemaakt))                                                                    AS toestandsdatum,
+       'Toestandsdatum, d.i. de laatste aanmaakdatum van de BRK-berichten in de naar DIVA gerepliceerde BRK-levering.' AS omschrijving
 FROM brk2.bestand bsd
+;

--- a/src/data/sql/brk2/select.meta.sql
+++ b/src/data/sql/brk2/select.meta.sql
@@ -1,5 +1,5 @@
-SELECT 1                                                                                                               AS id,
-       DATE_TRUNC('DAY', MAX(bsd.datum_aangemaakt))                                                                    AS toestandsdatum,
-       'Toestandsdatum, d.i. de laatste aanmaakdatum van de BRK-berichten in de naar DIVA gerepliceerde BRK-levering.' AS omschrijving
+SELECT 1                                                                                                        AS id,
+       DATE_TRUNC('DAY', MAX(bsd.datum_aangemaakt))                                                             AS toestandsdatum,
+       'Toestandsdatum, d.i. de laatste aanmaakdatum van de BRK-berichten in de laatst verwerkte BRK-levering.' AS omschrijving
 FROM brk2.bestand bsd
 ;

--- a/src/data/sql/brk2/select.meta.sql
+++ b/src/data/sql/brk2/select.meta.sql
@@ -2,4 +2,4 @@ SELECT
     1 as id,
     bsd.brk_bsd_toestandsdatum as toestandsdatum,
     bsd.omschrijving
-FROM brk2_prep.bestand bsd
+FROM brk2.bestand bsd

--- a/src/data/sql/brk2/select.meta.sql
+++ b/src/data/sql/brk2/select.meta.sql
@@ -2,4 +2,4 @@ SELECT
     1 as id,
     bsd.brk_bsd_toestandsdatum as toestandsdatum,
     bsd.omschrijving
-FROM brk2.bestand bsd
+FROM brk2_prep.bestand bsd

--- a/src/data/sql/brk2/select.stukdeel.sql
+++ b/src/data/sql/brk2/select.stukdeel.sql
@@ -119,7 +119,7 @@ FROM brk2.stukdeel sdl
                     GROUP BY q.is_gebaseerd_op_brk_stukdeel_identificatie) ec
                    ON sdl.identificatie = ec.stukdeel_identificatie
          LEFT OUTER JOIN brk2_prep.id_conversion idc ON idc.ident_nieuw = stk.identificatie
-         JOIN brk2_prep.bestand bsd ON TRUE
+         JOIN brk2.bestand bsd ON TRUE
 WHERE COALESCE(
                 tng.tng_ids -> 0 -> 'tng_identificatie',
                 akt.akt_ids -> 0 -> 'akt_identificatie',

--- a/src/data/sql/brk2/select.stukdeel.sql
+++ b/src/data/sql/brk2/select.stukdeel.sql
@@ -21,7 +21,7 @@ SELECT sdl.id                                                               AS i
        stk.soortregister_code                                               AS soort_register_stuk_code,
        srr.omschrijving                                                     AS soort_register_stuk_omschrijving,
        stk.deel                                                             AS deel_soort_stuk,
-       bsd.brk_bsd_toestandsdatum                                           AS toestandsdatum,
+       meta.toestandsdatum                                                  AS toestandsdatum,
        stk.tekeningingeschreven                                             AS tekening_ingeschreven,
        stk.tijdstipondertekening                                            AS tijdstip_ondertekening,
        stk.toelichtingbewaarder                                             AS toelichting_bewaarder,
@@ -119,7 +119,7 @@ FROM brk2.stukdeel sdl
                     GROUP BY q.is_gebaseerd_op_brk_stukdeel_identificatie) ec
                    ON sdl.identificatie = ec.stukdeel_identificatie
          LEFT OUTER JOIN brk2_prep.id_conversion idc ON idc.ident_nieuw = stk.identificatie
-         JOIN brk2.bestand bsd ON TRUE
+         JOIN brk2_prep.meta meta ON TRUE
 WHERE COALESCE(
                 tng.tng_ids -> 0 -> 'tng_identificatie',
                 akt.akt_ids -> 0 -> 'akt_identificatie',

--- a/src/data/sql/brk2/select.stukdeel.sql
+++ b/src/data/sql/brk2/select.stukdeel.sql
@@ -119,7 +119,7 @@ FROM brk2.stukdeel sdl
                     GROUP BY q.is_gebaseerd_op_brk_stukdeel_identificatie) ec
                    ON sdl.identificatie = ec.stukdeel_identificatie
          LEFT OUTER JOIN brk2_prep.id_conversion idc ON idc.ident_nieuw = stk.identificatie
-         JOIN brk2.bestand bsd ON TRUE
+         JOIN brk2_prep.bestand bsd ON TRUE
 WHERE COALESCE(
                 tng.tng_ids -> 0 -> 'tng_identificatie',
                 akt.akt_ids -> 0 -> 'akt_identificatie',


### PR DESCRIPTION
Be sure those tables are dropped before a new run by clearing brk2_prep

~~TODO: create_bestand_table task should be moved to databricks as part of the clone~~

`brk2.bestand` should be available from the databricks clone, use this table for the meta task