### PR TITLE
correction of number of rows in monumenten tables

### DIFF
--- a/src/data/monumenten.prepare.json
+++ b/src/data/monumenten.prepare.json
@@ -52,8 +52,8 @@
       "id": "check_row_counts",
       "table_row_counts": {
         "monumenten_prep.complexen": 100,
-        "monumenten_prep.monumenten": 9881,
-        "monumenten_prep.situeringen": 64099
+        "monumenten_prep.monumenten": 9781,
+        "monumenten_prep.situeringen": 63974
       },
       "margin_percentage": 5,
       "depends_on": [


### PR DESCRIPTION
Het correcte aantal rijen toegevoegd. de deleted rows moeten afgetrokken zijn van het aantal rijen in monumenten tabellen.